### PR TITLE
Promote spec-defined fields to typed model fields (0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,60 @@
 # Change log
 
+## 0.4.0
+
+### Typed first-class fields
+
+Spec-defined fields that previously only appeared in `model_extra` are now proper typed model fields:
+
+| Model | New typed fields |
+|-------|------------------|
+| `Schema` | `ref` (`$ref`), `format`, `enum`, `default`, `const`, `deprecated`, `nullable`, `read_only`, `write_only`, `example`, `examples`, `discriminator`, `additional_properties` (`Schema \| bool`), `minimum`, `maximum`, `exclusive_minimum`, `exclusive_maximum`, `multiple_of`, `min_length`, `max_length`, `pattern`, `min_items`, `max_items`, `unique_items`, `min_properties`, `max_properties` |
+| `Operation` | `parameters` (`list[Parameter]`), `responses` (`dict[str, Response]`), `request_body`, `security` (`None` = inherit global), `callbacks` (`dict[str, Callback]`), `deprecated`, `servers`, `external_docs` |
+| `MediaType` | `schema_` is now a typed `Schema` instead of a raw dict |
+| `Parameter` | `ref`, `deprecated`, `allow_empty_value` |
+| `Header` | `ref`, `deprecated` |
+| `RequestBody` / `Response` | `ref` |
+| `Encoding` | `headers` is now `dict[str, Header]` |
+| `Link` | snake_case fields (`operation_ref`, `operation_id`, `request_body`) with camelCase aliases; typed `server` |
+| `PathItem` | `ref`, `summary`, `description`, typed path-level `parameters` |
+
+- `Schema.has_default` / `Schema.has_const` distinguish an explicit `default: null` from an absent default.
+- New `Discriminator` model (`property_name`, `mapping`) wired into `Schema.discriminator`.
+- All models accept construction by field name as well as alias (`populate_by_name`).
+
+### Deprecated: model_extra mirroring
+
+For backwards compatibility, the raw source values of all promoted keys are still mirrored into `model_extra` (e.g. `schema.model_extra["$ref"]` and `operation.model_extra["requestBody"]` keep working and return the same raw data as 0.3.0). **This mirroring is deprecated and will be removed in 0.5.0** — migrate to the typed fields.
+
+Known behavior changes that mirroring does not cover:
+
+- `Operation.parameters` / `Operation.responses` previously held raw dicts; they now hold typed `Parameter` / `Response` objects (`param["name"]` becomes `param.name`, `param.get("$ref")` becomes `param.ref`).
+- `MediaType.schema_` previously held a raw dict; it now holds a typed `Schema`.
+- `Link.operationRef` / `Link.operationId` / `Link.requestBody` field names are now snake_case; the old camelCase attribute access still works via the mirrored extras until 0.5.0.
+- `schema.model_dump(by_alias=True, exclude_unset=True)` is now a near drop-in replacement for hand-rolled model-to-dict conversions.
+
+### Native OpenAPI 3.1 nullability
+
+- `Schema.types`: always-a-list view of the `type` keyword (handles 3.1 type arrays like `type: ["string", "null"]`).
+- `Schema.primary_type`: first non-`"null"` type.
+- `Schema.is_nullable`: unifies the 3.0 `nullable` keyword, 3.1 type arrays containing `"null"`, and `anyOf`/`oneOf` with a `{"type": "null"}` member. OpenAPI 3.1 specs no longer need to be normalized to 3.0 before parsing.
+
+### Query API
+
+- `OpenAPISpec.operations_by_tag(tag)` and `OpenAPISpec.tags_to_operations()` for tag-based operation lookup.
+- `Paths` is iterable as `(path, PathItem)` pairs and supports `len()`.
+- Reference resolution is cached: one shared resolver per spec plus a per-resolver result cache (repeated `resolve_reference` calls return the same object).
+- Broken reference errors include a did-you-mean suggestion and the available keys at the failure point.
+
+### Robustness
+
+- Boolean JSON schemas (`items: true`, `additionalProperties: false`) no longer crash parsing; `additionalProperties` preserves booleans, boolean `items` are skipped.
+- Malformed nested values of the wrong shape are skipped (the field keeps its default) instead of crashing the parse; raw values remain available via `model_extra` where mirrored.
+
+### Internals
+
+- New `model_utils.SpecModel` base class with a declarative, generic `from_dict`, removing the hand-written boilerplate from most models.
+
 ## 0.3.0
 
 - Fixed path-level parameters not being merged into operation parameters.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It's fast, minimal, fully typed, and pythonic.
 - **Tested at scale**: We run tests against 4000+ real schemas from [APIs.guru OpenAPI Directory](https://github.com/APIs-guru/openapi-directory).
 - **Pydantic models**: All models are type-safe.
 - **Multiple input formats**: Files, URLs, or in-memory data.
-- **OpenAPI 3.x support**: Works with OpenAPI 3.0 and 3.1 specifications.
+- **OpenAPI 3.x support**: Works with OpenAPI 3.0 and 3.1 specifications, including native handling of 3.1 type arrays (`Schema.is_nullable`, `Schema.primary_type`).
 - **Minimal dependencies**: Just Pydantic and pyyaml. Everything else is stdlib.
 - **Simple API**: Easy to use, hard to misuse.
 - **Modern Python**: Fully typed with 100% test coverage.

--- a/cicerone/references/reference_resolver.py
+++ b/cicerone/references/reference_resolver.py
@@ -11,6 +11,7 @@ References:
 
 from __future__ import annotations
 
+import difflib
 import typing
 
 import pydantic
@@ -57,6 +58,8 @@ class ReferenceResolver:
         """
         self.spec = spec
         self._resolution_stack: list[str] = []
+        # Cache of fully resolved references, keyed by (ref string, follow_nested)
+        self._cache: dict[tuple[str, bool], typing.Any] = {}
 
     def resolve_reference(
         self,
@@ -90,6 +93,11 @@ class ReferenceResolver:
         if ref.ref in self._resolution_stack:
             raise RecursionError(f"Circular reference detected: {' -> '.join(self._resolution_stack + [ref.ref])}")
 
+        # Return cached results for references that aren't currently in flight
+        cache_key = (ref.ref, follow_nested)
+        if cache_key in self._cache:
+            return self._cache[cache_key]
+
         # Add to resolution stack for circular reference detection
         self._resolution_stack.append(ref.ref)
 
@@ -104,12 +112,12 @@ class ReferenceResolver:
             # If the target is itself a reference and we should follow it
             if follow_nested and spec_reference.Reference.is_reference(target):
                 nested_ref = spec_reference.Reference.from_dict(target)
-                return self.resolve_reference(nested_ref, follow_nested=True)
-
+                target = self.resolve_reference(nested_ref, follow_nested=True)
             # If follow_nested is True and target is a typed object, resolve nested $refs
-            if follow_nested and not isinstance(target, dict):
+            elif follow_nested and not isinstance(target, dict):
                 target = self._resolve_nested_references(target)
 
+            self._cache[cache_key] = target
             return target
 
         finally:
@@ -142,7 +150,15 @@ class ReferenceResolver:
             try:
                 current = current[int(part)] if isinstance(current, list) else current[part]
             except (KeyError, IndexError, ValueError) as e:
-                raise ValueError(f"Reference path not found: {ref.ref} (failed at {path_so_far})") from e
+                message = f"Reference path not found: {ref.ref} (failed at {path_so_far})"
+                if isinstance(current, dict):
+                    available = sorted(str(key) for key in current.keys())
+                    if close_matches := difflib.get_close_matches(part, available, n=1):
+                        message += f". Did you mean '{close_matches[0]}'?"
+                    preview = ", ".join(available[:20])
+                    suffix = ", ..." if len(available) > 20 else ""
+                    message += f" Available keys: {preview}{suffix}"
+                raise ValueError(message) from e
             except TypeError as e:
                 raise ValueError(
                     f"Cannot navigate through non-dict/list object: {ref.ref} (failed at {path_so_far})"

--- a/cicerone/references/reference_resolver.py
+++ b/cicerone/references/reference_resolver.py
@@ -210,7 +210,10 @@ class ReferenceResolver:
         return obj
 
     def _get_ref_from_model(self, model: pydantic.BaseModel) -> str | None:
-        """Extract $ref from a Pydantic model's extra fields if present.
+        """Extract $ref from a Pydantic model if present.
+
+        Checks the typed ``ref`` field first (Schema, Parameter, Response, etc.),
+        then falls back to extra fields for models without a typed field.
 
         Args:
             model: Pydantic model to check
@@ -218,7 +221,12 @@ class ReferenceResolver:
         Returns:
             The $ref string if found, None otherwise
         """
-        return getattr(model, "__pydantic_extra__", {}).get("$ref")
+        if "ref" in type(model).model_fields:
+            ref = getattr(model, "ref", None)
+            if isinstance(ref, str) and ref:
+                return ref
+        extra = getattr(model, "__pydantic_extra__", None) or {}
+        return extra.get("$ref")
 
     def _try_resolve_ref(self, ref: str) -> typing.Any | None:
         """Attempt to resolve a reference, returning None on failure.

--- a/cicerone/spec/__init__.py
+++ b/cicerone/spec/__init__.py
@@ -2,6 +2,7 @@
 
 from cicerone.spec.callback import Callback
 from cicerone.spec.components import Components
+from cicerone.spec.discriminator import Discriminator
 from cicerone.spec.encoding import Encoding
 from cicerone.spec.example import Example
 from cicerone.spec.header import Header
@@ -27,12 +28,16 @@ Header.model_rebuild()
 Parameter.model_rebuild()
 Response.model_rebuild()
 Components.model_rebuild()
+Operation.model_rebuild()
+PathItem.model_rebuild()
+Callback.model_rebuild()
 
 __all__ = [
     "Callback",
     "Components",
     "Contact",
     "Contact",
+    "Discriminator",
     "Encoding",
     "Example",
     "ExternalDocumentation",

--- a/cicerone/spec/callback.py
+++ b/cicerone/spec/callback.py
@@ -10,8 +10,6 @@ import typing
 
 import pydantic
 
-from cicerone.spec import path_item as spec_path_item
-
 
 class Callback(pydantic.BaseModel):
     """Represents an OpenAPI Callback Object.
@@ -53,3 +51,10 @@ class Callback(pydantic.BaseModel):
             PathItem if found, None otherwise
         """
         return self.expressions.get(expression)
+
+
+# Imported after the class definition to break the import cycle:
+# callback -> path_item -> operation -> callback
+from cicerone.spec import path_item as spec_path_item  # noqa: E402
+
+Callback.model_rebuild(raise_errors=False)

--- a/cicerone/spec/discriminator.py
+++ b/cicerone/spec/discriminator.py
@@ -1,0 +1,37 @@
+"""Discriminator model for OpenAPI discriminator objects.
+
+References:
+- OpenAPI 3.x Discriminator Object: https://spec.openapis.org/oas/v3.1.0#discriminator-object
+"""
+
+from __future__ import annotations
+
+import typing
+
+import pydantic
+
+
+class Discriminator(pydantic.BaseModel):
+    """Represents an OpenAPI Discriminator Object.
+
+    Used with oneOf/anyOf/allOf composition to hint which schema a payload
+    matches, based on the value of a named property.
+    """
+
+    # Allow extra fields to support vendor extensions and future spec additions
+    model_config = {"extra": "allow", "populate_by_name": True}
+
+    property_name: str = pydantic.Field(alias="propertyName")
+    mapping: dict[str, str] = pydantic.Field(default_factory=dict)
+
+    def __str__(self) -> str:
+        """Return a readable string representation of the discriminator."""
+        parts = [f"propertyName={self.property_name}"]
+        if self.mapping:
+            parts.append(f"{len(self.mapping)} mappings")
+        return f"<Discriminator: {', '.join(parts)}>"
+
+    @classmethod
+    def from_dict(cls, data: dict[str, typing.Any]) -> Discriminator:
+        """Create a Discriminator from a dictionary."""
+        return cls(**data)

--- a/cicerone/spec/encoding.py
+++ b/cicerone/spec/encoding.py
@@ -14,25 +14,18 @@ from cicerone.spec import header as spec_header
 from cicerone.spec import model_utils
 
 
-class Encoding(pydantic.BaseModel):
+class Encoding(model_utils.SpecModel):
     """Represents an OpenAPI Encoding Object.
 
     An encoding definition applied to a single schema property.
     """
 
-    # Allow extra fields to support vendor extensions
-    model_config = {"extra": "allow", "populate_by_name": True}
+    NESTED_FIELDS: typing.ClassVar[dict[str, model_utils.NestedField]] = {
+        "headers": model_utils.NestedField("collection", spec_header.Header.from_dict),
+    }
 
     contentType: str | None = None
     headers: dict[str, spec_header.Header] = pydantic.Field(default_factory=dict)
     style: str | None = None
     explode: bool = False
     allowReserved: bool = False
-
-    @classmethod
-    def from_dict(cls, data: dict[str, typing.Any]) -> Encoding:
-        """Create an Encoding from a dictionary."""
-        return cls(
-            headers=model_utils.parse_collection(data, "headers", spec_header.Header.from_dict),
-            **{k: v for k, v in data.items() if k != "headers"},
-        )

--- a/cicerone/spec/encoding.py
+++ b/cicerone/spec/encoding.py
@@ -10,6 +10,9 @@ import typing
 
 import pydantic
 
+from cicerone.spec import header as spec_header
+from cicerone.spec import model_utils
+
 
 class Encoding(pydantic.BaseModel):
     """Represents an OpenAPI Encoding Object.
@@ -18,10 +21,10 @@ class Encoding(pydantic.BaseModel):
     """
 
     # Allow extra fields to support vendor extensions
-    model_config = {"extra": "allow"}
+    model_config = {"extra": "allow", "populate_by_name": True}
 
     contentType: str | None = None
-    headers: dict[str, typing.Any] = pydantic.Field(default_factory=dict)  # Header objects
+    headers: dict[str, spec_header.Header] = pydantic.Field(default_factory=dict)
     style: str | None = None
     explode: bool = False
     allowReserved: bool = False
@@ -29,5 +32,7 @@ class Encoding(pydantic.BaseModel):
     @classmethod
     def from_dict(cls, data: dict[str, typing.Any]) -> Encoding:
         """Create an Encoding from a dictionary."""
-        # Simple passthrough - pydantic handles all fields with extra="allow"
-        return cls(**data)
+        return cls(
+            headers=model_utils.parse_collection(data, "headers", spec_header.Header.from_dict),
+            **{k: v for k, v in data.items() if k != "headers"},
+        )

--- a/cicerone/spec/example.py
+++ b/cicerone/spec/example.py
@@ -16,3 +16,7 @@ class Example(model_utils.SpecModel):
     description: str | None = None
     value: typing.Any | None = None
     externalValue: str | None = None
+
+    # Malformed scalar values fall back to the field default instead of
+    # rejecting the whole document
+    _lenient_scalars = model_utils.lenient_validator("summary", "description", "externalValue")

--- a/cicerone/spec/example.py
+++ b/cicerone/spec/example.py
@@ -6,22 +6,13 @@ References:
 
 import typing
 
-import pydantic
+from cicerone.spec import model_utils
 
 
-class Example(pydantic.BaseModel):
+class Example(model_utils.SpecModel):
     """Represents an OpenAPI example object."""
-
-    # Allow extra fields to support vendor extensions and future spec additions
-    model_config = {"extra": "allow"}
 
     summary: str | None = None
     description: str | None = None
     value: typing.Any | None = None
     externalValue: str | None = None
-
-    @classmethod
-    def from_dict(cls, data: dict[str, typing.Any]) -> "Example":
-        """Create an Example from a dictionary."""
-        # Simple passthrough - pydantic handles all fields with extra="allow"
-        return cls(**data)

--- a/cicerone/spec/header.py
+++ b/cicerone/spec/header.py
@@ -36,3 +36,7 @@ class Header(model_utils.SpecModel):
     explode: bool | None = None
     example: typing.Any | None = None
     examples: dict[str, spec_example.Example] = pydantic.Field(default_factory=dict)
+
+    # Malformed scalar values fall back to the field default instead of
+    # rejecting the whole document
+    _lenient_scalars = model_utils.lenient_validator("ref", "description", "required", "deprecated", "style", "explode")

--- a/cicerone/spec/header.py
+++ b/cicerone/spec/header.py
@@ -19,10 +19,16 @@ class Header(pydantic.BaseModel):
     """Represents an OpenAPI header object."""
 
     # Allow extra fields to support vendor extensions and future spec additions
-    model_config = {"extra": "allow"}
+    model_config = {"extra": "allow", "populate_by_name": True}
 
+    # Keys promoted to typed fields in 0.4.0 that are still mirrored into
+    # model_extra for backwards compatibility (removed in 0.5.0)
+    MIRRORED_EXTRA_KEYS: typing.ClassVar[tuple[str, ...]] = ("$ref", "deprecated")
+
+    ref: str | None = pydantic.Field(None, alias="$ref")
     description: str | None = None
     required: bool = False
+    deprecated: bool = False
     schema_: spec_schema.Schema | None = pydantic.Field(None, alias="schema")
     style: str | None = None
     explode: bool | None = None
@@ -33,7 +39,7 @@ class Header(pydantic.BaseModel):
     def from_dict(cls, data: dict[str, typing.Any]) -> Header:
         """Create a Header from a dictionary."""
         excluded = {"description", "required", "schema", "style", "explode", "example", "examples"}
-        return cls(
+        header = cls(
             description=data.get("description"),
             required=data.get("required", False),
             schema=model_utils.parse_nested_object(data, "schema", spec_schema.Schema.from_dict),
@@ -43,3 +49,5 @@ class Header(pydantic.BaseModel):
             examples=model_utils.parse_collection(data, "examples", spec_example.Example.from_dict),
             **{k: v for k, v in data.items() if k not in excluded},
         )
+        model_utils.mirror_extras(header, data, cls.MIRRORED_EXTRA_KEYS)
+        return header

--- a/cicerone/spec/header.py
+++ b/cicerone/spec/header.py
@@ -15,11 +15,13 @@ from cicerone.spec import model_utils
 from cicerone.spec import schema as spec_schema
 
 
-class Header(pydantic.BaseModel):
+class Header(model_utils.SpecModel):
     """Represents an OpenAPI header object."""
 
-    # Allow extra fields to support vendor extensions and future spec additions
-    model_config = {"extra": "allow", "populate_by_name": True}
+    NESTED_FIELDS: typing.ClassVar[dict[str, model_utils.NestedField]] = {
+        "schema": model_utils.NestedField("object", spec_schema.Schema.from_dict),
+        "examples": model_utils.NestedField("collection", spec_example.Example.from_dict),
+    }
 
     # Keys promoted to typed fields in 0.4.0 that are still mirrored into
     # model_extra for backwards compatibility (removed in 0.5.0)
@@ -34,20 +36,3 @@ class Header(pydantic.BaseModel):
     explode: bool | None = None
     example: typing.Any | None = None
     examples: dict[str, spec_example.Example] = pydantic.Field(default_factory=dict)
-
-    @classmethod
-    def from_dict(cls, data: dict[str, typing.Any]) -> Header:
-        """Create a Header from a dictionary."""
-        excluded = {"description", "required", "schema", "style", "explode", "example", "examples"}
-        header = cls(
-            description=data.get("description"),
-            required=data.get("required", False),
-            schema=model_utils.parse_nested_object(data, "schema", spec_schema.Schema.from_dict),
-            style=data.get("style"),
-            explode=data.get("explode"),
-            example=data.get("example"),
-            examples=model_utils.parse_collection(data, "examples", spec_example.Example.from_dict),
-            **{k: v for k, v in data.items() if k not in excluded},
-        )
-        model_utils.mirror_extras(header, data, cls.MIRRORED_EXTRA_KEYS)
-        return header

--- a/cicerone/spec/link.py
+++ b/cicerone/spec/link.py
@@ -14,11 +14,12 @@ from cicerone.spec import model_utils
 from cicerone.spec import server as spec_server
 
 
-class Link(pydantic.BaseModel):
+class Link(model_utils.SpecModel):
     """Represents an OpenAPI Link Object."""
 
-    # Allow extra fields to support vendor extensions and future spec additions
-    model_config = {"extra": "allow", "populate_by_name": True}
+    NESTED_FIELDS: typing.ClassVar[dict[str, model_utils.NestedField]] = {
+        "server": model_utils.NestedField("object", spec_server.Server.from_dict),
+    }
 
     # Keys renamed to snake_case fields in 0.4.0 that are still mirrored into
     # model_extra for backwards-compatible attribute access (removed in 0.5.0)
@@ -30,13 +31,3 @@ class Link(pydantic.BaseModel):
     request_body: typing.Any | None = pydantic.Field(None, alias="requestBody")
     description: str | None = None
     server: spec_server.Server | None = None
-
-    @classmethod
-    def from_dict(cls, data: dict[str, typing.Any]) -> "Link":
-        """Create a Link from a dictionary."""
-        link = cls(
-            server=model_utils.parse_nested_object(data, "server", spec_server.Server.from_dict),
-            **{k: v for k, v in data.items() if k != "server"},
-        )
-        model_utils.mirror_extras(link, data, cls.MIRRORED_EXTRA_KEYS)
-        return link

--- a/cicerone/spec/link.py
+++ b/cicerone/spec/link.py
@@ -4,26 +4,39 @@ References:
 - OpenAPI 3.x Link Object: https://spec.openapis.org/oas/v3.1.0#link-object
 """
 
+from __future__ import annotations
+
 import typing
 
 import pydantic
+
+from cicerone.spec import model_utils
+from cicerone.spec import server as spec_server
 
 
 class Link(pydantic.BaseModel):
     """Represents an OpenAPI Link Object."""
 
     # Allow extra fields to support vendor extensions and future spec additions
-    model_config = {"extra": "allow"}
+    model_config = {"extra": "allow", "populate_by_name": True}
 
-    operationRef: str | None = None
-    operationId: str | None = None
+    # Keys renamed to snake_case fields in 0.4.0 that are still mirrored into
+    # model_extra for backwards-compatible attribute access (removed in 0.5.0)
+    MIRRORED_EXTRA_KEYS: typing.ClassVar[tuple[str, ...]] = ("operationRef", "operationId", "requestBody")
+
+    operation_ref: str | None = pydantic.Field(None, alias="operationRef")
+    operation_id: str | None = pydantic.Field(None, alias="operationId")
     parameters: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
-    requestBody: typing.Any | None = None
+    request_body: typing.Any | None = pydantic.Field(None, alias="requestBody")
     description: str | None = None
-    server: dict[str, typing.Any] | None = None
+    server: spec_server.Server | None = None
 
     @classmethod
     def from_dict(cls, data: dict[str, typing.Any]) -> "Link":
         """Create a Link from a dictionary."""
-        # Simple passthrough - pydantic handles all fields with extra="allow"
-        return cls(**data)
+        link = cls(
+            server=model_utils.parse_nested_object(data, "server", spec_server.Server.from_dict),
+            **{k: v for k, v in data.items() if k != "server"},
+        )
+        model_utils.mirror_extras(link, data, cls.MIRRORED_EXTRA_KEYS)
+        return link

--- a/cicerone/spec/media_type.py
+++ b/cicerone/spec/media_type.py
@@ -13,15 +13,16 @@ import pydantic
 from cicerone.spec import encoding as spec_encoding
 from cicerone.spec import example as spec_example
 from cicerone.spec import model_utils
+from cicerone.spec import schema as spec_schema
 
 
 class MediaType(pydantic.BaseModel):
     """Represents an OpenAPI Media Type Object."""
 
     # Allow extra fields to support vendor extensions and future spec additions
-    model_config = {"extra": "allow"}
+    model_config = {"extra": "allow", "populate_by_name": True}
 
-    schema_: dict[str, typing.Any] | None = pydantic.Field(None, alias="schema")
+    schema_: spec_schema.Schema | None = pydantic.Field(None, alias="schema")
     example: typing.Any | None = None
     examples: dict[str, spec_example.Example] = pydantic.Field(default_factory=dict)
     encoding: dict[str, spec_encoding.Encoding] = pydantic.Field(default_factory=dict)
@@ -29,8 +30,10 @@ class MediaType(pydantic.BaseModel):
     @classmethod
     def from_dict(cls, data: dict[str, typing.Any]) -> MediaType:
         """Create a MediaType from a dictionary."""
+        # JSON Schema allows boolean schemas (true/false); only parse dict values
+        schema_value = data.get("schema")
         return cls(
-            schema=data.get("schema"),
+            schema=spec_schema.Schema.from_dict(schema_value) if isinstance(schema_value, dict) else None,
             example=data.get("example"),
             examples=model_utils.parse_collection(data, "examples", spec_example.Example.from_dict),
             encoding=model_utils.parse_collection(data, "encoding", spec_encoding.Encoding.from_dict),

--- a/cicerone/spec/media_type.py
+++ b/cicerone/spec/media_type.py
@@ -16,26 +16,16 @@ from cicerone.spec import model_utils
 from cicerone.spec import schema as spec_schema
 
 
-class MediaType(pydantic.BaseModel):
+class MediaType(model_utils.SpecModel):
     """Represents an OpenAPI Media Type Object."""
 
-    # Allow extra fields to support vendor extensions and future spec additions
-    model_config = {"extra": "allow", "populate_by_name": True}
+    NESTED_FIELDS: typing.ClassVar[dict[str, model_utils.NestedField]] = {
+        "schema": model_utils.NestedField("object", spec_schema.Schema.from_dict),
+        "examples": model_utils.NestedField("collection", spec_example.Example.from_dict),
+        "encoding": model_utils.NestedField("collection", spec_encoding.Encoding.from_dict),
+    }
 
     schema_: spec_schema.Schema | None = pydantic.Field(None, alias="schema")
     example: typing.Any | None = None
     examples: dict[str, spec_example.Example] = pydantic.Field(default_factory=dict)
     encoding: dict[str, spec_encoding.Encoding] = pydantic.Field(default_factory=dict)
-
-    @classmethod
-    def from_dict(cls, data: dict[str, typing.Any]) -> MediaType:
-        """Create a MediaType from a dictionary."""
-        # JSON Schema allows boolean schemas (true/false); only parse dict values
-        schema_value = data.get("schema")
-        return cls(
-            schema=spec_schema.Schema.from_dict(schema_value) if isinstance(schema_value, dict) else None,
-            example=data.get("example"),
-            examples=model_utils.parse_collection(data, "examples", spec_example.Example.from_dict),
-            encoding=model_utils.parse_collection(data, "encoding", spec_encoding.Encoding.from_dict),
-            **{k: v for k, v in data.items() if k not in {"schema", "example", "examples", "encoding"}},
-        )

--- a/cicerone/spec/model_utils.py
+++ b/cicerone/spec/model_utils.py
@@ -119,9 +119,7 @@ class SpecModel(pydantic.BaseModel):
                         kwargs[wire_name] = nested.parser(value)
                 case "collection":
                     if isinstance(value, dict):
-                        kwargs[wire_name] = {
-                            name: nested.parser(item) for name, item in value.items() if isinstance(item, dict)
-                        }
+                        kwargs[wire_name] = parse_collection(data, wire_name, nested.parser)
                 case "list":
                     if isinstance(value, list):
                         kwargs[wire_name] = [nested.parser(item) for item in value if isinstance(item, dict)]
@@ -176,6 +174,10 @@ def parse_collection(
 ) -> dict[str, T]:
     """Parse a collection of objects into a dictionary.
 
+    Malformed entries degrade gracefully: a non-dict collection yields an
+    empty dict, non-dict items are skipped, and non-string keys (e.g. YAML
+    parsing an unquoted ``no:`` key as boolean False) are coerced to str.
+
     Args:
         data: Source dictionary
         field_name: Name of field containing the collection
@@ -187,9 +189,14 @@ def parse_collection(
     Example:
         parse_collection(data, "examples", Example.from_dict)
     """
-    if field_name in data:
-        return {name: parser_func(item_data) for name, item_data in data[field_name].items()}
-    return {}
+    collection = data.get(field_name)
+    if not isinstance(collection, dict):
+        return {}
+    return {
+        (name if isinstance(name, str) else str(name)): parser_func(item_data)
+        for name, item_data in collection.items()
+        if isinstance(item_data, dict)
+    }
 
 
 def parse_list(

--- a/cicerone/spec/model_utils.py
+++ b/cicerone/spec/model_utils.py
@@ -8,7 +8,40 @@ from __future__ import annotations
 
 import typing
 
+if typing.TYPE_CHECKING:
+    import pydantic
+
 T = typing.TypeVar("T")
+
+
+def mirror_extras(
+    obj: pydantic.BaseModel,
+    data: typing.Mapping[str, typing.Any],
+    keys: typing.Iterable[str],
+) -> None:
+    """Mirror raw source values into a model's ``__pydantic_extra__``.
+
+    .. deprecated:: 0.4.0
+        This is a compatibility shim for consumers that accessed spec fields via
+        ``model_extra`` before they were promoted to typed model fields in 0.4.0.
+        The mirrored copies will be removed in 0.5.0 - use the typed fields instead.
+
+    Once a key is declared as a typed field, Pydantic routes it to the field and it
+    no longer appears in ``__pydantic_extra__``. This helper re-injects the raw
+    source values (not the parsed models) so that pre-0.4.0 access patterns like
+    ``schema.model_extra.get("enum")`` keep returning the same data.
+
+    Args:
+        obj: The freshly constructed model to mirror values onto
+        data: The raw source dictionary the model was parsed from
+        keys: The wire-format keys (e.g. "$ref", "requestBody") to mirror
+    """
+    extra = obj.__pydantic_extra__
+    if extra is None:
+        return
+    for key in keys:
+        if key in data and key not in extra:
+            extra[key] = data[key]
 
 
 def truncate_text(text: str, max_len: int = 50) -> str:

--- a/cicerone/spec/model_utils.py
+++ b/cicerone/spec/model_utils.py
@@ -43,6 +43,38 @@ def mirror_extras(
             extra[key] = data[key]
 
 
+def lenient_validator(*field_names: str) -> typing.Any:
+    """Create a wrap validator that falls back to the field default on bad input.
+
+    Real-world specs frequently contain malformed scalar values (e.g. YAML
+    parsing ``pattern: 0.0`` as a float, or Swagger-2-style ``required: true``
+    on a property schema). Rejecting the whole document for one bad keyword
+    would make cicerone unusable at scale, so the listed optional fields fall
+    back to their default instead. The raw value is still available via
+    ``model_extra`` (where mirrored) and ``OpenAPISpec.raw``.
+
+    Args:
+        field_names: Names of the optional fields to validate leniently
+
+    Returns:
+        A pydantic wrap validator to assign in the model class body
+    """
+
+    def _lenient(
+        cls: type[pydantic.BaseModel],
+        value: typing.Any,
+        handler: typing.Callable[[typing.Any], typing.Any],
+        info: pydantic.ValidationInfo,
+    ) -> typing.Any:
+        try:
+            return handler(value)
+        except pydantic.ValidationError:
+            assert info.field_name is not None
+            return cls.model_fields[info.field_name].get_default(call_default_factory=True)
+
+    return pydantic.field_validator(*field_names, mode="wrap")(classmethod(_lenient))
+
+
 class NestedField(typing.NamedTuple):
     """Declares how a nested wire-format key is parsed by SpecModel.from_dict.
 
@@ -87,7 +119,9 @@ class SpecModel(pydantic.BaseModel):
                         kwargs[wire_name] = nested.parser(value)
                 case "collection":
                     if isinstance(value, dict):
-                        kwargs[wire_name] = {name: nested.parser(item) for name, item in value.items()}
+                        kwargs[wire_name] = {
+                            name: nested.parser(item) for name, item in value.items() if isinstance(item, dict)
+                        }
                 case "list":
                     if isinstance(value, list):
                         kwargs[wire_name] = [nested.parser(item) for item in value if isinstance(item, dict)]

--- a/cicerone/spec/model_utils.py
+++ b/cicerone/spec/model_utils.py
@@ -8,8 +8,7 @@ from __future__ import annotations
 
 import typing
 
-if typing.TYPE_CHECKING:
-    import pydantic
+import pydantic
 
 T = typing.TypeVar("T")
 
@@ -42,6 +41,59 @@ def mirror_extras(
     for key in keys:
         if key in data and key not in extra:
             extra[key] = data[key]
+
+
+class NestedField(typing.NamedTuple):
+    """Declares how a nested wire-format key is parsed by SpecModel.from_dict.
+
+    Attributes:
+        kind: One of "object" (single nested object), "collection" (dict of
+            name -> object), or "list" (list of objects, non-dict items skipped)
+        parser: Function to parse each nested value (usually Class.from_dict)
+    """
+
+    kind: typing.Literal["object", "collection", "list"]
+    parser: typing.Callable[[dict[str, typing.Any]], typing.Any]
+
+
+class SpecModel(pydantic.BaseModel):
+    """Base class for OpenAPI spec models with a declarative from_dict.
+
+    Subclasses declare nested wire-format keys in ``NESTED_FIELDS``; all other
+    keys are passed straight to Pydantic, which resolves field aliases and
+    routes unknown keys into ``model_extra``. Keys listed in
+    ``MIRRORED_EXTRA_KEYS`` additionally have their raw values mirrored into
+    ``model_extra`` for backwards compatibility (deprecated, removed in 0.5.0).
+    """
+
+    # extra="allow" supports vendor extensions and future spec additions;
+    # populate_by_name allows programmatic construction with field names
+    model_config = {"extra": "allow", "populate_by_name": True}
+
+    NESTED_FIELDS: typing.ClassVar[dict[str, NestedField]] = {}
+    MIRRORED_EXTRA_KEYS: typing.ClassVar[tuple[str, ...]] = ()
+
+    @classmethod
+    def from_dict(cls, data: dict[str, typing.Any]) -> typing.Self:
+        """Create a model instance from a raw spec dictionary."""
+        kwargs: dict[str, typing.Any] = {k: v for k, v in data.items() if k not in cls.NESTED_FIELDS}
+        for wire_name, nested in cls.NESTED_FIELDS.items():
+            value = data.get(wire_name)
+            # Malformed values of the wrong shape are skipped so the field
+            # falls back to its default instead of crashing the parse
+            match nested.kind:
+                case "object":
+                    if isinstance(value, dict):
+                        kwargs[wire_name] = nested.parser(value)
+                case "collection":
+                    if isinstance(value, dict):
+                        kwargs[wire_name] = {name: nested.parser(item) for name, item in value.items()}
+                case "list":
+                    if isinstance(value, list):
+                        kwargs[wire_name] = [nested.parser(item) for item in value if isinstance(item, dict)]
+        obj = cls(**kwargs)
+        mirror_extras(obj, data, cls.MIRRORED_EXTRA_KEYS)
+        return obj
 
 
 def truncate_text(text: str, max_len: int = 50) -> str:

--- a/cicerone/spec/openapi_spec.py
+++ b/cicerone/spec/openapi_spec.py
@@ -43,6 +43,9 @@ class OpenAPISpec(pydantic.BaseModel):
     tags: list[spec_tag.Tag] = pydantic.Field(default_factory=list)
     external_docs: spec_tag.ExternalDocumentation | None = pydantic.Field(None, alias="externalDocs")
 
+    # Lazily created, shared resolver so resolved references are cached per spec
+    _resolver: spec_reference_resolver.ReferenceResolver | None = pydantic.PrivateAttr(default=None)
+
     def __str__(self) -> str:
         """Return a readable string representation of the OpenAPI spec."""
         title = self.raw.get("info", {}).get("title", "Untitled")
@@ -83,6 +86,46 @@ class OpenAPISpec(pydantic.BaseModel):
         """
         yield from itertools.chain(self.paths.all_operations(), self.webhooks.all_operations())
 
+    def operations_by_tag(self, tag: str) -> typing.Generator[spec_operation.Operation, None, None]:
+        """Yield all operations (from paths and webhooks) carrying the given tag.
+
+        Args:
+            tag: The tag name to filter by
+
+        Yields:
+            Operation objects tagged with the given tag
+
+        Example:
+            >>> from cicerone.parse import parse_spec_from_file
+            >>> spec = parse_spec_from_file("openapi.yaml")
+            >>> for op in spec.operations_by_tag("users"):
+            ...     print(op.operation_id)
+        """
+        for operation in self.all_operations():
+            if tag in operation.tags:
+                yield operation
+
+    def tags_to_operations(self) -> dict[str, list[spec_operation.Operation]]:
+        """Group all operations by tag.
+
+        Operations with multiple tags appear under each of their tags.
+        Untagged operations are not included.
+
+        Returns:
+            Dictionary mapping tag names to lists of Operation objects
+
+        Example:
+            >>> from cicerone.parse import parse_spec_from_file
+            >>> spec = parse_spec_from_file("openapi.yaml")
+            >>> grouped = spec.tags_to_operations()
+            >>> user_ops = grouped.get("users", [])
+        """
+        grouped: dict[str, list[spec_operation.Operation]] = {}
+        for operation in self.all_operations():
+            for tag in operation.tags:
+                grouped.setdefault(tag, []).append(operation)
+        return grouped
+
     def resolve_reference(
         self,
         ref: spec_reference.Reference | str,
@@ -113,8 +156,7 @@ class OpenAPISpec(pydantic.BaseModel):
             >>> # Returns a Schema object, not a dict
             >>> print(type(user_schema))  # <class 'cicerone.spec.schema.Schema'>
         """
-        resolver = spec_reference_resolver.ReferenceResolver(self)
-        return resolver.resolve_reference(ref, follow_nested=follow_nested)
+        return self._get_resolver().resolve_reference(ref, follow_nested=follow_nested)
 
     def get_all_references(self) -> dict[str, spec_reference.Reference]:
         """Get all references in the specification.
@@ -135,5 +177,10 @@ class OpenAPISpec(pydantic.BaseModel):
             >>> local_refs = {k: v for k, v in all_refs.items() if v.is_local}
             >>> print(f"Found {len(all_refs)} references")
         """
-        resolver = spec_reference_resolver.ReferenceResolver(self)
-        return resolver.get_all_references()
+        return self._get_resolver().get_all_references()
+
+    def _get_resolver(self) -> spec_reference_resolver.ReferenceResolver:
+        """Return the spec's shared, lazily created reference resolver."""
+        if self._resolver is None:
+            self._resolver = spec_reference_resolver.ReferenceResolver(self)
+        return self._resolver

--- a/cicerone/spec/operation.py
+++ b/cicerone/spec/operation.py
@@ -110,7 +110,7 @@ class Operation(pydantic.BaseModel):
                 if isinstance(p, dict)
             ],
             responses={
-                status: spec_response.Response.from_dict(response_data)
+                (status if isinstance(status, str) else str(status)): spec_response.Response.from_dict(response_data)
                 for status, response_data in (
                     responses_data.items() if isinstance(responses_data, typing.Mapping) else []
                 )

--- a/cicerone/spec/operation.py
+++ b/cicerone/spec/operation.py
@@ -67,6 +67,12 @@ class Operation(pydantic.BaseModel):
     servers: list[spec_server.Server] = pydantic.Field(default_factory=list)
     external_docs: spec_tag.ExternalDocumentation | None = pydantic.Field(None, alias="externalDocs")
 
+    # Malformed scalar values fall back to the field default instead of
+    # rejecting the whole document
+    _lenient_scalars = model_utils.lenient_validator(
+        "operation_id", "summary", "description", "tags", "deprecated", "security"
+    )
+
     def __str__(self) -> str:
         """Return a readable string representation of the operation."""
         parts = [f"{self.method} {self.path}"]

--- a/cicerone/spec/operation.py
+++ b/cicerone/spec/operation.py
@@ -10,12 +10,19 @@ import typing
 
 import pydantic
 
+from cicerone.spec import model_utils
+from cicerone.spec import parameter as spec_parameter
+from cicerone.spec import request_body as spec_request_body
+from cicerone.spec import response as spec_response
+from cicerone.spec import server as spec_server
+from cicerone.spec import tag as spec_tag
+
 
 class Operation(pydantic.BaseModel):
     """Represents an HTTP operation (GET, POST, etc.)."""
 
     # Allow extra fields to support vendor extensions and future spec additions
-    model_config = {"extra": "allow"}
+    model_config = {"extra": "allow", "populate_by_name": True}
 
     # Fields that are explicitly mapped in from_dict() to avoid double-processing
     EXPLICITLY_MAPPED_FIELDS: typing.ClassVar[set[str]] = {
@@ -25,7 +32,24 @@ class Operation(pydantic.BaseModel):
         "tags",
         "parameters",
         "responses",
+        "requestBody",
+        "security",
+        "callbacks",
+        "deprecated",
+        "servers",
+        "externalDocs",
     }
+
+    # Keys promoted to typed fields in 0.4.0 that are still mirrored into
+    # model_extra for backwards compatibility (removed in 0.5.0)
+    MIRRORED_EXTRA_KEYS: typing.ClassVar[tuple[str, ...]] = (
+        "requestBody",
+        "security",
+        "callbacks",
+        "deprecated",
+        "servers",
+        "externalDocs",
+    )
 
     method: str
     path: str
@@ -33,8 +57,15 @@ class Operation(pydantic.BaseModel):
     summary: str | None = None
     description: str | None = None
     tags: list[str] = pydantic.Field(default_factory=list)
-    parameters: list[typing.Any] = pydantic.Field(default_factory=list)
-    responses: dict[str, typing.Any] = pydantic.Field(default_factory=dict)
+    parameters: list[spec_parameter.Parameter] = pydantic.Field(default_factory=list)
+    responses: dict[str, spec_response.Response] = pydantic.Field(default_factory=dict)
+    request_body: spec_request_body.RequestBody | None = pydantic.Field(None, alias="requestBody")
+    # None means "inherit the global security requirements", distinct from [] (no security)
+    security: list[dict[str, list[str]]] | None = None
+    callbacks: dict[str, "spec_callback.Callback"] = pydantic.Field(default_factory=dict)
+    deprecated: bool = False
+    servers: list[spec_server.Server] = pydantic.Field(default_factory=list)
+    external_docs: spec_tag.ExternalDocumentation | None = pydantic.Field(None, alias="externalDocs")
 
     def __str__(self) -> str:
         """Return a readable string representation of the operation."""
@@ -45,19 +76,73 @@ class Operation(pydantic.BaseModel):
             parts.append(f"'{self.summary}'")
         if self.tags:
             parts.append(f"tags={self.tags}")
+        if self.deprecated:
+            parts.append("deprecated")
         return f"<Operation: {', '.join(parts)}>"
 
     @classmethod
     def from_dict(cls, method: str, path: str, data: typing.Mapping[str, typing.Any]) -> "Operation":
         """Create an Operation from a dictionary."""
-        return cls(
+        # Skip non-dict entries so malformed specs degrade gracefully; the raw
+        # values are still available via the mirrored model_extra copies
+        parameters_data = data.get("parameters", [])
+        responses_data = data.get("responses", {})
+        request_body_data = data.get("requestBody")
+        security_data = data.get("security")
+        callbacks_data = data.get("callbacks", {})
+        external_docs_data = data.get("externalDocs")
+        operation = cls(
             method=method,
             path=path,
             operationId=data.get("operationId"),
             summary=data.get("summary"),
             description=data.get("description"),
             tags=data.get("tags", []),
-            parameters=data.get("parameters", []),
-            responses=data.get("responses", {}),
+            parameters=[
+                spec_parameter.Parameter.from_dict(p)
+                for p in (parameters_data if isinstance(parameters_data, list) else [])
+                if isinstance(p, dict)
+            ],
+            responses={
+                status: spec_response.Response.from_dict(response_data)
+                for status, response_data in (
+                    responses_data.items() if isinstance(responses_data, typing.Mapping) else []
+                )
+                if isinstance(response_data, dict)
+            },
+            requestBody=(
+                spec_request_body.RequestBody.from_dict(request_body_data)
+                if isinstance(request_body_data, dict)
+                else None
+            ),
+            security=security_data if isinstance(security_data, list) else None,
+            callbacks={
+                expression: spec_callback.Callback.from_dict(callback_data)
+                for expression, callback_data in (
+                    callbacks_data.items() if isinstance(callbacks_data, typing.Mapping) else []
+                )
+                if isinstance(callback_data, dict)
+            },
+            deprecated=data.get("deprecated", False),
+            servers=[
+                spec_server.Server.from_dict(s) for s in data.get("servers", []) if isinstance(s, dict) and "url" in s
+            ],
+            externalDocs=(
+                spec_tag.ExternalDocumentation.from_dict(external_docs_data)
+                if isinstance(external_docs_data, dict) and "url" in external_docs_data
+                else None
+            ),
             **{k: v for k, v in data.items() if k not in cls.EXPLICITLY_MAPPED_FIELDS},
         )
+        model_utils.mirror_extras(operation, data, cls.MIRRORED_EXTRA_KEYS)
+        return operation
+
+
+# Imported after the class definition to break the import cycle:
+# operation -> callback -> path_item -> operation
+from cicerone.spec import callback as spec_callback  # noqa: E402
+
+# When callback.py is mid-import (it imports operation via path_item), the rebuild
+# cannot complete yet; cicerone/spec/__init__.py performs the final rebuild
+if hasattr(spec_callback, "Callback"):
+    Operation.model_rebuild(raise_errors=False)

--- a/cicerone/spec/parameter.py
+++ b/cicerone/spec/parameter.py
@@ -19,12 +19,19 @@ class Parameter(pydantic.BaseModel):
     """Represents an OpenAPI parameter object."""
 
     # Allow extra fields to support vendor extensions and future spec additions
-    model_config = {"extra": "allow"}
+    model_config = {"extra": "allow", "populate_by_name": True}
 
+    # Keys promoted to typed fields in 0.4.0 that are still mirrored into
+    # model_extra for backwards compatibility (removed in 0.5.0)
+    MIRRORED_EXTRA_KEYS: typing.ClassVar[tuple[str, ...]] = ("$ref", "deprecated", "allowEmptyValue")
+
+    ref: str | None = pydantic.Field(None, alias="$ref")
     name: str | None = None
     in_: str | None = pydantic.Field(None, alias="in")
     description: str | None = None
     required: bool = False
+    deprecated: bool = False
+    allow_empty_value: bool | None = pydantic.Field(None, alias="allowEmptyValue")
     schema_: spec_schema.Schema | None = pydantic.Field(None, alias="schema")
     # OpenAPI 3.x fields
     style: str | None = None
@@ -46,7 +53,7 @@ class Parameter(pydantic.BaseModel):
             "example",
             "examples",
         }
-        return cls(
+        parameter = cls(
             name=data.get("name"),
             **{"in": data.get("in")},
             description=data.get("description"),
@@ -58,3 +65,5 @@ class Parameter(pydantic.BaseModel):
             examples=model_utils.parse_collection(data, "examples", spec_example.Example.from_dict),
             **{k: v for k, v in data.items() if k not in excluded},
         )
+        model_utils.mirror_extras(parameter, data, cls.MIRRORED_EXTRA_KEYS)
+        return parameter

--- a/cicerone/spec/parameter.py
+++ b/cicerone/spec/parameter.py
@@ -15,11 +15,13 @@ from cicerone.spec import model_utils
 from cicerone.spec import schema as spec_schema
 
 
-class Parameter(pydantic.BaseModel):
+class Parameter(model_utils.SpecModel):
     """Represents an OpenAPI parameter object."""
 
-    # Allow extra fields to support vendor extensions and future spec additions
-    model_config = {"extra": "allow", "populate_by_name": True}
+    NESTED_FIELDS: typing.ClassVar[dict[str, model_utils.NestedField]] = {
+        "schema": model_utils.NestedField("object", spec_schema.Schema.from_dict),
+        "examples": model_utils.NestedField("collection", spec_example.Example.from_dict),
+    }
 
     # Keys promoted to typed fields in 0.4.0 that are still mirrored into
     # model_extra for backwards compatibility (removed in 0.5.0)
@@ -38,32 +40,3 @@ class Parameter(pydantic.BaseModel):
     explode: bool | None = None
     example: typing.Any | None = None
     examples: dict[str, spec_example.Example] = pydantic.Field(default_factory=dict)
-
-    @classmethod
-    def from_dict(cls, data: dict[str, typing.Any]) -> Parameter:
-        """Create a Parameter from a dictionary."""
-        excluded = {
-            "name",
-            "in",
-            "description",
-            "required",
-            "schema",
-            "style",
-            "explode",
-            "example",
-            "examples",
-        }
-        parameter = cls(
-            name=data.get("name"),
-            **{"in": data.get("in")},
-            description=data.get("description"),
-            required=data.get("required", False),
-            schema=model_utils.parse_nested_object(data, "schema", spec_schema.Schema.from_dict),
-            style=data.get("style"),
-            explode=data.get("explode"),
-            example=data.get("example"),
-            examples=model_utils.parse_collection(data, "examples", spec_example.Example.from_dict),
-            **{k: v for k, v in data.items() if k not in excluded},
-        )
-        model_utils.mirror_extras(parameter, data, cls.MIRRORED_EXTRA_KEYS)
-        return parameter

--- a/cicerone/spec/parameter.py
+++ b/cicerone/spec/parameter.py
@@ -40,3 +40,9 @@ class Parameter(model_utils.SpecModel):
     explode: bool | None = None
     example: typing.Any | None = None
     examples: dict[str, spec_example.Example] = pydantic.Field(default_factory=dict)
+
+    # Malformed scalar values fall back to the field default instead of
+    # rejecting the whole document
+    _lenient_scalars = model_utils.lenient_validator(
+        "ref", "name", "in_", "description", "required", "deprecated", "allow_empty_value", "style", "explode"
+    )

--- a/cicerone/spec/path_item.py
+++ b/cicerone/spec/path_item.py
@@ -9,16 +9,24 @@ import typing
 import pydantic
 
 from cicerone.spec import operation as spec_operation
+from cicerone.spec import parameter as spec_parameter
+
+HTTP_METHODS = ["get", "post", "put", "patch", "delete", "options", "head", "trace"]
 
 
 class PathItem(pydantic.BaseModel):
     """Represents a path item with its operations."""
 
     # Allow extra fields to support vendor extensions and path-level parameters
-    model_config = {"extra": "allow"}
+    model_config = {"extra": "allow", "populate_by_name": True}
 
     path: str
+    ref: str | None = pydantic.Field(None, alias="$ref")
+    summary: str | None = None
+    description: str | None = None
     operations: dict[str, spec_operation.Operation] = pydantic.Field(default_factory=dict)
+    # Path-level parameters, also merged into each operation's parameters below
+    parameters: list[spec_parameter.Parameter] = pydantic.Field(default_factory=list)
 
     def __str__(self) -> str:
         """Return a readable string representation of the path item."""
@@ -29,14 +37,18 @@ class PathItem(pydantic.BaseModel):
     def from_dict(cls, path: str, data: typing.Mapping[str, typing.Any]) -> "PathItem":
         """Create a PathItem from a dictionary."""
         operations = {}
-        http_methods = ["get", "post", "put", "patch", "delete", "options", "head", "trace"]
 
-        # Extract path-level parameters if they exist
         # Note: We check isinstance as a defensive measure because some callers
         # (like callbacks with invalid test data) may pass non-Mapping types
-        path_level_parameters = data.get("parameters", []) if isinstance(data, typing.Mapping) else []
+        if not isinstance(data, typing.Mapping):
+            return cls(path=path)
 
-        for method in http_methods:
+        # Extract path-level parameters if they exist
+        path_level_parameters = data.get("parameters", [])
+        if not isinstance(path_level_parameters, list):
+            path_level_parameters = []
+
+        for method in HTTP_METHODS:
             if method in data:
                 # Only create a copy if we need to merge path-level parameters
                 if path_level_parameters:
@@ -50,4 +62,13 @@ class PathItem(pydantic.BaseModel):
                     # No path-level parameters, use operation data as-is
                     operations[method] = spec_operation.Operation.from_dict(method.upper(), path, data[method])
 
-        return cls(path=path, operations=operations)
+        excluded = set(HTTP_METHODS) | {"parameters", "summary", "description", "$ref"}
+        return cls(
+            path=path,
+            operations=operations,
+            summary=data.get("summary"),
+            description=data.get("description"),
+            parameters=[spec_parameter.Parameter.from_dict(p) for p in path_level_parameters if isinstance(p, dict)],
+            **{"$ref": data.get("$ref")} if "$ref" in data else {},
+            **{k: v for k, v in data.items() if k not in excluded},
+        )

--- a/cicerone/spec/path_item.py
+++ b/cicerone/spec/path_item.py
@@ -8,6 +8,7 @@ import typing
 
 import pydantic
 
+from cicerone.spec import model_utils
 from cicerone.spec import operation as spec_operation
 from cicerone.spec import parameter as spec_parameter
 
@@ -27,6 +28,10 @@ class PathItem(pydantic.BaseModel):
     operations: dict[str, spec_operation.Operation] = pydantic.Field(default_factory=dict)
     # Path-level parameters, also merged into each operation's parameters below
     parameters: list[spec_parameter.Parameter] = pydantic.Field(default_factory=list)
+
+    # Malformed scalar values fall back to the field default instead of
+    # rejecting the whole document
+    _lenient_scalars = model_utils.lenient_validator("ref", "summary", "description")
 
     def __str__(self) -> str:
         """Return a readable string representation of the path item."""
@@ -62,13 +67,12 @@ class PathItem(pydantic.BaseModel):
                     # No path-level parameters, use operation data as-is
                     operations[method] = spec_operation.Operation.from_dict(method.upper(), path, data[method])
 
-        excluded = set(HTTP_METHODS) | {"parameters", "summary", "description", "$ref"}
+        # The splat resolves $ref/summary/description via Pydantic aliases and
+        # routes unknown keys into model_extra
+        excluded = set(HTTP_METHODS) | {"parameters"}
         return cls(
             path=path,
             operations=operations,
-            summary=data.get("summary"),
-            description=data.get("description"),
             parameters=[spec_parameter.Parameter.from_dict(p) for p in path_level_parameters if isinstance(p, dict)],
-            **{"$ref": data.get("$ref")} if "$ref" in data else {},
             **{k: v for k, v in data.items() if k not in excluded},
         )

--- a/cicerone/spec/paths.py
+++ b/cicerone/spec/paths.py
@@ -39,6 +39,19 @@ class Paths(pydantic.BaseModel):
         """Check if a path exists."""
         return path in self.items
 
+    def __iter__(self) -> typing.Iterator[tuple[str, spec_path_item.PathItem]]:  # type: ignore[override]
+        """Iterate over (path, PathItem) pairs.
+
+        Note: this intentionally overrides Pydantic's default model iteration
+        (which yields (field_name, value) pairs) so that consumers can write
+        ``for path, path_item in spec.paths:`` directly.
+        """
+        yield from self.items.items()
+
+    def __len__(self) -> int:
+        """Return the number of paths."""
+        return len(self.items)
+
     def all_operations(self) -> typing.Generator[spec_operation.Operation, None, None]:
         """Yield all operations across all paths."""
         for path_item in self.items.values():

--- a/cicerone/spec/request_body.py
+++ b/cicerone/spec/request_body.py
@@ -14,11 +14,12 @@ from cicerone.spec import media_type as spec_media_type
 from cicerone.spec import model_utils
 
 
-class RequestBody(pydantic.BaseModel):
+class RequestBody(model_utils.SpecModel):
     """Represents an OpenAPI request body object."""
 
-    # Allow extra fields to support vendor extensions and future spec additions
-    model_config = {"extra": "allow", "populate_by_name": True}
+    NESTED_FIELDS: typing.ClassVar[dict[str, model_utils.NestedField]] = {
+        "content": model_utils.NestedField("collection", spec_media_type.MediaType.from_dict),
+    }
 
     # Keys promoted to typed fields in 0.4.0 that are still mirrored into
     # model_extra for backwards compatibility (removed in 0.5.0)
@@ -28,15 +29,3 @@ class RequestBody(pydantic.BaseModel):
     description: str | None = None
     content: dict[str, spec_media_type.MediaType] = pydantic.Field(default_factory=dict)
     required: bool = False
-
-    @classmethod
-    def from_dict(cls, data: dict[str, typing.Any]) -> "RequestBody":
-        """Create a RequestBody from a dictionary."""
-        request_body = cls(
-            description=data.get("description"),
-            content=model_utils.parse_collection(data, "content", spec_media_type.MediaType.from_dict),
-            required=data.get("required", False),
-            **{k: v for k, v in data.items() if k not in {"description", "content", "required"}},
-        )
-        model_utils.mirror_extras(request_body, data, cls.MIRRORED_EXTRA_KEYS)
-        return request_body

--- a/cicerone/spec/request_body.py
+++ b/cicerone/spec/request_body.py
@@ -18,8 +18,13 @@ class RequestBody(pydantic.BaseModel):
     """Represents an OpenAPI request body object."""
 
     # Allow extra fields to support vendor extensions and future spec additions
-    model_config = {"extra": "allow"}
+    model_config = {"extra": "allow", "populate_by_name": True}
 
+    # Keys promoted to typed fields in 0.4.0 that are still mirrored into
+    # model_extra for backwards compatibility (removed in 0.5.0)
+    MIRRORED_EXTRA_KEYS: typing.ClassVar[tuple[str, ...]] = ("$ref",)
+
+    ref: str | None = pydantic.Field(None, alias="$ref")
     description: str | None = None
     content: dict[str, spec_media_type.MediaType] = pydantic.Field(default_factory=dict)
     required: bool = False
@@ -27,9 +32,11 @@ class RequestBody(pydantic.BaseModel):
     @classmethod
     def from_dict(cls, data: dict[str, typing.Any]) -> "RequestBody":
         """Create a RequestBody from a dictionary."""
-        return cls(
+        request_body = cls(
             description=data.get("description"),
             content=model_utils.parse_collection(data, "content", spec_media_type.MediaType.from_dict),
             required=data.get("required", False),
             **{k: v for k, v in data.items() if k not in {"description", "content", "required"}},
         )
+        model_utils.mirror_extras(request_body, data, cls.MIRRORED_EXTRA_KEYS)
+        return request_body

--- a/cicerone/spec/request_body.py
+++ b/cicerone/spec/request_body.py
@@ -29,3 +29,7 @@ class RequestBody(model_utils.SpecModel):
     description: str | None = None
     content: dict[str, spec_media_type.MediaType] = pydantic.Field(default_factory=dict)
     required: bool = False
+
+    # Malformed scalar values fall back to the field default instead of
+    # rejecting the whole document
+    _lenient_scalars = model_utils.lenient_validator("ref", "description", "required")

--- a/cicerone/spec/response.py
+++ b/cicerone/spec/response.py
@@ -21,8 +21,13 @@ class Response(pydantic.BaseModel):
     """Represents an OpenAPI response object."""
 
     # Allow extra fields to support vendor extensions and future spec additions
-    model_config = {"extra": "allow"}
+    model_config = {"extra": "allow", "populate_by_name": True}
 
+    # Keys promoted to typed fields in 0.4.0 that are still mirrored into
+    # model_extra for backwards compatibility (removed in 0.5.0)
+    MIRRORED_EXTRA_KEYS: typing.ClassVar[tuple[str, ...]] = ("$ref",)
+
+    ref: str | None = pydantic.Field(None, alias="$ref")
     description: str | None = None
     content: dict[str, spec_media_type.MediaType] = pydantic.Field(default_factory=dict)
     headers: dict[str, spec_header.Header] = pydantic.Field(default_factory=dict)
@@ -33,7 +38,7 @@ class Response(pydantic.BaseModel):
     def from_dict(cls, data: dict[str, typing.Any]) -> Response:
         """Create a Response from a dictionary."""
         excluded = {"description", "content", "headers", "links", "examples"}
-        return cls(
+        response = cls(
             description=data.get("description"),
             content=model_utils.parse_collection(data, "content", spec_media_type.MediaType.from_dict),
             headers=model_utils.parse_collection(data, "headers", spec_header.Header.from_dict),
@@ -41,3 +46,5 @@ class Response(pydantic.BaseModel):
             examples=model_utils.parse_collection(data, "examples", spec_example.Example.from_dict),
             **{k: v for k, v in data.items() if k not in excluded},
         )
+        model_utils.mirror_extras(response, data, cls.MIRRORED_EXTRA_KEYS)
+        return response

--- a/cicerone/spec/response.py
+++ b/cicerone/spec/response.py
@@ -17,11 +17,15 @@ from cicerone.spec import media_type as spec_media_type
 from cicerone.spec import model_utils
 
 
-class Response(pydantic.BaseModel):
+class Response(model_utils.SpecModel):
     """Represents an OpenAPI response object."""
 
-    # Allow extra fields to support vendor extensions and future spec additions
-    model_config = {"extra": "allow", "populate_by_name": True}
+    NESTED_FIELDS: typing.ClassVar[dict[str, model_utils.NestedField]] = {
+        "content": model_utils.NestedField("collection", spec_media_type.MediaType.from_dict),
+        "headers": model_utils.NestedField("collection", spec_header.Header.from_dict),
+        "links": model_utils.NestedField("collection", spec_link.Link.from_dict),
+        "examples": model_utils.NestedField("collection", spec_example.Example.from_dict),
+    }
 
     # Keys promoted to typed fields in 0.4.0 that are still mirrored into
     # model_extra for backwards compatibility (removed in 0.5.0)
@@ -33,18 +37,3 @@ class Response(pydantic.BaseModel):
     headers: dict[str, spec_header.Header] = pydantic.Field(default_factory=dict)
     links: dict[str, spec_link.Link] = pydantic.Field(default_factory=dict)
     examples: dict[str, spec_example.Example] = pydantic.Field(default_factory=dict)
-
-    @classmethod
-    def from_dict(cls, data: dict[str, typing.Any]) -> Response:
-        """Create a Response from a dictionary."""
-        excluded = {"description", "content", "headers", "links", "examples"}
-        response = cls(
-            description=data.get("description"),
-            content=model_utils.parse_collection(data, "content", spec_media_type.MediaType.from_dict),
-            headers=model_utils.parse_collection(data, "headers", spec_header.Header.from_dict),
-            links=model_utils.parse_collection(data, "links", spec_link.Link.from_dict),
-            examples=model_utils.parse_collection(data, "examples", spec_example.Example.from_dict),
-            **{k: v for k, v in data.items() if k not in excluded},
-        )
-        model_utils.mirror_extras(response, data, cls.MIRRORED_EXTRA_KEYS)
-        return response

--- a/cicerone/spec/response.py
+++ b/cicerone/spec/response.py
@@ -37,3 +37,7 @@ class Response(model_utils.SpecModel):
     headers: dict[str, spec_header.Header] = pydantic.Field(default_factory=dict)
     links: dict[str, spec_link.Link] = pydantic.Field(default_factory=dict)
     examples: dict[str, spec_example.Example] = pydantic.Field(default_factory=dict)
+
+    # Malformed scalar values fall back to the field default instead of
+    # rejecting the whole document
+    _lenient_scalars = model_utils.lenient_validator("ref", "description")

--- a/cicerone/spec/schema.py
+++ b/cicerone/spec/schema.py
@@ -15,11 +15,12 @@ from cicerone.spec import discriminator as spec_discriminator
 from cicerone.spec import model_utils
 
 
-class Schema(pydantic.BaseModel):
-    """Represents a JSON Schema / OpenAPI Schema object."""
+class Schema(model_utils.SpecModel):
+    """Represents a JSON Schema / OpenAPI Schema object.
 
-    # Allow extra fields to support full JSON Schema vocabulary and vendor extensions
-    model_config = {"extra": "allow", "populate_by_name": True}
+    Extra fields are allowed to support the full JSON Schema vocabulary and
+    vendor extensions.
+    """
 
     # Keys whose values are themselves schemas (or schema containers) and need
     # recursive parsing in from_dict() rather than plain Pydantic validation

--- a/cicerone/spec/schema.py
+++ b/cicerone/spec/schema.py
@@ -27,6 +27,7 @@ class Schema(model_utils.SpecModel):
     NESTED_SCHEMA_KEYS: typing.ClassVar[set[str]] = {
         "properties",
         "items",
+        "prefixItems",
         "allOf",
         "oneOf",
         "anyOf",
@@ -49,6 +50,7 @@ class Schema(model_utils.SpecModel):
         "writeOnly",
         "discriminator",
         "additionalProperties",
+        "prefixItems",
         "example",
         "examples",
         "minimum",
@@ -74,6 +76,8 @@ class Schema(model_utils.SpecModel):
     properties: dict[str, Schema] = pydantic.Field(default_factory=dict)
     required: list[str] = pydantic.Field(default_factory=list)
     items: Schema | None = None
+    # JSON Schema tuple validation (OpenAPI 3.1)
+    prefix_items: list[Schema] | None = pydantic.Field(None, alias="prefixItems")
     # Value keywords
     enum: list[typing.Any] | None = None
     default: typing.Any = None
@@ -111,6 +115,37 @@ class Schema(model_utils.SpecModel):
     min_properties: int | None = pydantic.Field(None, alias="minProperties")
     max_properties: int | None = pydantic.Field(None, alias="maxProperties")
 
+    # Malformed scalar values in real-world specs fall back to the field
+    # default instead of rejecting the whole document (raw value stays
+    # available via model_extra and OpenAPISpec.raw)
+    _lenient_scalars = model_utils.lenient_validator(
+        "ref",
+        "title",
+        "type",
+        "format",
+        "description",
+        "required",
+        "enum",
+        "examples",
+        "deprecated",
+        "nullable",
+        "read_only",
+        "write_only",
+        "minimum",
+        "maximum",
+        "exclusive_minimum",
+        "exclusive_maximum",
+        "multiple_of",
+        "min_length",
+        "max_length",
+        "pattern",
+        "min_items",
+        "max_items",
+        "unique_items",
+        "min_properties",
+        "max_properties",
+    )
+
     def __str__(self) -> str:
         """Return a readable string representation of the schema."""
         parts = []
@@ -128,6 +163,8 @@ class Schema(model_utils.SpecModel):
             parts.append(f"required={self.required}")
         if self.items:
             parts.append(f"items={self.items.type or 'object'}")
+        if self.prefix_items:
+            parts.append(f"prefixItems=({', '.join(str(item.type or 'object') for item in self.prefix_items)})")
 
         content = ", ".join(parts) if parts else "empty schema"
         return f"<Schema: {content}>"
@@ -190,7 +227,7 @@ class Schema(model_utils.SpecModel):
         items = data.get("items")
         if isinstance(items, dict):
             kwargs["items"] = cls.from_dict(items)
-        for key in ("allOf", "oneOf", "anyOf"):
+        for key in ("prefixItems", "allOf", "oneOf", "anyOf"):
             parsed = model_utils.parse_list_or_none(data, key, cls.from_dict)
             if parsed is not None:
                 kwargs[key] = parsed

--- a/cicerone/spec/schema.py
+++ b/cicerone/spec/schema.py
@@ -11,6 +11,7 @@ import typing
 
 import pydantic
 
+from cicerone.spec import discriminator as spec_discriminator
 from cicerone.spec import model_utils
 
 
@@ -18,27 +19,108 @@ class Schema(pydantic.BaseModel):
     """Represents a JSON Schema / OpenAPI Schema object."""
 
     # Allow extra fields to support full JSON Schema vocabulary and vendor extensions
-    model_config = {"extra": "allow"}
+    model_config = {"extra": "allow", "populate_by_name": True}
 
+    # Keys whose values are themselves schemas (or schema containers) and need
+    # recursive parsing in from_dict() rather than plain Pydantic validation
+    NESTED_SCHEMA_KEYS: typing.ClassVar[set[str]] = {
+        "properties",
+        "items",
+        "allOf",
+        "oneOf",
+        "anyOf",
+        "not",
+        "additionalProperties",
+        "discriminator",
+    }
+
+    # Keys promoted to typed fields in 0.4.0 that are still mirrored into
+    # model_extra for backwards compatibility (removed in 0.5.0)
+    MIRRORED_EXTRA_KEYS: typing.ClassVar[tuple[str, ...]] = (
+        "$ref",
+        "format",
+        "enum",
+        "default",
+        "const",
+        "deprecated",
+        "nullable",
+        "readOnly",
+        "writeOnly",
+        "discriminator",
+        "additionalProperties",
+        "example",
+        "examples",
+        "minimum",
+        "maximum",
+        "exclusiveMinimum",
+        "exclusiveMaximum",
+        "multipleOf",
+        "minLength",
+        "maxLength",
+        "pattern",
+        "minItems",
+        "maxItems",
+        "uniqueItems",
+        "minProperties",
+        "maxProperties",
+    )
+
+    ref: str | None = pydantic.Field(None, alias="$ref")
     title: str | None = None
     type: str | list[str] | None = None
+    format: str | None = None
     description: str | None = None
     properties: dict[str, Schema] = pydantic.Field(default_factory=dict)
     required: list[str] = pydantic.Field(default_factory=list)
     items: Schema | None = None
+    # Value keywords
+    enum: list[typing.Any] | None = None
+    default: typing.Any = None
+    const: typing.Any = None
+    example: typing.Any = None
+    # JSON Schema uses a list for `examples`; some real-world 3.0 specs use a dict
+    examples: list[typing.Any] | dict[str, typing.Any] | None = None
+    # Metadata keywords
+    deprecated: bool = False
+    nullable: bool | None = None  # OpenAPI 3.0 keyword (3.1 uses type arrays)
+    read_only: bool | None = pydantic.Field(None, alias="readOnly")
+    write_only: bool | None = pydantic.Field(None, alias="writeOnly")
     # Composition keywords
     all_of: list[Schema] | None = pydantic.Field(None, alias="allOf")
     one_of: list[Schema] | None = pydantic.Field(None, alias="oneOf")
     any_of: list[Schema] | None = pydantic.Field(None, alias="anyOf")
     not_: Schema | None = pydantic.Field(None, alias="not")
+    discriminator: spec_discriminator.Discriminator | None = None
+    additional_properties: Schema | bool | None = pydantic.Field(None, alias="additionalProperties")
+    # Numeric constraints (exclusiveMinimum/Maximum are bool in 3.0, number in 3.1)
+    minimum: float | None = None
+    maximum: float | None = None
+    exclusive_minimum: bool | float | None = pydantic.Field(None, alias="exclusiveMinimum")
+    exclusive_maximum: bool | float | None = pydantic.Field(None, alias="exclusiveMaximum")
+    multiple_of: float | None = pydantic.Field(None, alias="multipleOf")
+    # String constraints
+    min_length: int | None = pydantic.Field(None, alias="minLength")
+    max_length: int | None = pydantic.Field(None, alias="maxLength")
+    pattern: str | None = None
+    # Array constraints
+    min_items: int | None = pydantic.Field(None, alias="minItems")
+    max_items: int | None = pydantic.Field(None, alias="maxItems")
+    unique_items: bool | None = pydantic.Field(None, alias="uniqueItems")
+    # Object constraints
+    min_properties: int | None = pydantic.Field(None, alias="minProperties")
+    max_properties: int | None = pydantic.Field(None, alias="maxProperties")
 
     def __str__(self) -> str:
         """Return a readable string representation of the schema."""
         parts = []
+        if self.ref:
+            parts.append(f"ref={self.ref}")
         if self.title:
             parts.append(f"'{self.title}'")
         if self.type:
             parts.append(f"type={self.type}")
+        if self.enum:
+            parts.append(f"enum[{len(self.enum)}]")
         if self.properties:
             parts.append(f"{len(self.properties)} properties")
         if self.required:
@@ -49,33 +131,44 @@ class Schema(pydantic.BaseModel):
         content = ", ".join(parts) if parts else "empty schema"
         return f"<Schema: {content}>"
 
+    @property
+    def has_default(self) -> bool:
+        """True if the schema explicitly declares a default (including ``default: null``)."""
+        return "default" in self.model_fields_set
+
+    @property
+    def has_const(self) -> bool:
+        """True if the schema explicitly declares a const (including ``const: null``)."""
+        return "const" in self.model_fields_set
+
     @classmethod
     def from_dict(cls, data: dict[str, typing.Any]) -> Schema:
         """Create a Schema from a dictionary, handling nested schemas."""
-        excluded = {
-            "title",
-            "type",
-            "description",
-            "required",
-            "properties",
-            "items",
-            "allOf",
-            "oneOf",
-            "anyOf",
-            "not",
-        }
+        # All scalar fields resolve via Pydantic aliases when the raw keys are
+        # splatted; only schema-valued keys need recursive parsing
+        kwargs: dict[str, typing.Any] = {k: v for k, v in data.items() if k not in cls.NESTED_SCHEMA_KEYS}
 
-        return cls(
-            title=data.get("title"),
-            type=data.get("type"),
-            description=data.get("description"),
-            required=data.get("required", []),
-            properties=model_utils.parse_collection(data, "properties", cls.from_dict),
-            items=model_utils.parse_nested_object(data, "items", cls.from_dict),
-            allOf=model_utils.parse_list_or_none(data, "allOf", cls.from_dict),
-            oneOf=model_utils.parse_list_or_none(data, "oneOf", cls.from_dict),
-            anyOf=model_utils.parse_list_or_none(data, "anyOf", cls.from_dict),
-            # Use dict unpacking for 'not' since it's a Python keyword
-            **{"not": model_utils.parse_nested_object(data, "not", cls.from_dict)} if "not" in data else {},
-            **{k: v for k, v in data.items() if k not in excluded},
-        )
+        kwargs["properties"] = model_utils.parse_collection(data, "properties", cls.from_dict)
+        # JSON Schema allows boolean schemas (true/false); only parse dict values
+        items = data.get("items")
+        if isinstance(items, dict):
+            kwargs["items"] = cls.from_dict(items)
+        for key in ("allOf", "oneOf", "anyOf"):
+            parsed = model_utils.parse_list_or_none(data, key, cls.from_dict)
+            if parsed is not None:
+                kwargs[key] = parsed
+        not_value = data.get("not")
+        if isinstance(not_value, dict):
+            kwargs["not"] = cls.from_dict(not_value)
+        additional = data.get("additionalProperties")
+        if isinstance(additional, dict):
+            kwargs["additionalProperties"] = cls.from_dict(additional)
+        elif isinstance(additional, bool):
+            kwargs["additionalProperties"] = additional
+        discriminator_value = data.get("discriminator")
+        if isinstance(discriminator_value, dict):
+            kwargs["discriminator"] = spec_discriminator.Discriminator.from_dict(discriminator_value)
+
+        schema = cls(**kwargs)
+        model_utils.mirror_extras(schema, data, cls.MIRRORED_EXTRA_KEYS)
+        return schema

--- a/cicerone/spec/schema.py
+++ b/cicerone/spec/schema.py
@@ -132,6 +132,42 @@ class Schema(pydantic.BaseModel):
         return f"<Schema: {content}>"
 
     @property
+    def types(self) -> list[str]:
+        """Always-a-list view of the ``type`` keyword.
+
+        OpenAPI 3.1 allows type arrays (``type: ["string", "null"]``) while 3.0
+        only allows a single string. This property unifies both forms; it returns
+        an empty list when ``type`` is unset.
+        """
+        if self.type is None:
+            return []
+        if isinstance(self.type, str):
+            return [self.type]
+        return list(self.type)
+
+    @property
+    def primary_type(self) -> str | None:
+        """The first non-``"null"`` type, or None if there isn't one."""
+        return next((t for t in self.types if t != "null"), None)
+
+    @property
+    def is_nullable(self) -> bool:
+        """True if the schema accepts null values.
+
+        Unifies the OpenAPI 3.0 ``nullable`` keyword, OpenAPI 3.1 type arrays
+        containing ``"null"``, and anyOf/oneOf compositions with a
+        ``{"type": "null"}`` member.
+        """
+        if self.nullable:
+            return True
+        if "null" in self.types:
+            return True
+        for members in (self.any_of, self.one_of):
+            if members and any("null" in member.types for member in members):
+                return True
+        return False
+
+    @property
     def has_default(self) -> bool:
         """True if the schema explicitly declares a default (including ``default: null``)."""
         return "default" in self.model_fields_set

--- a/docs/models.md
+++ b/docs/models.md
@@ -69,7 +69,9 @@ The top-level model representing an entire OpenAPI specification.
 
 - `operation_by_operation_id(operation_id)`: Find an operation object by its operationId
 - `all_operations()`: Generator yielding all operation objects
-- `resolve_reference(ref)`: Resolve a $ref reference
+- `operations_by_tag(tag)`: Generator yielding all operations carrying the given tag
+- `tags_to_operations()`: Group all operations by tag
+- `resolve_reference(ref)`: Resolve a $ref reference (results are cached per spec)
 - `get_all_references()`: Get all references in the spec
 
 **Example:**
@@ -127,18 +129,36 @@ Represents a JSON Schema / OpenAPI Schema object. This is one of the most common
 
 **Key Attributes:**
 
-- `type` (str | None): Schema type (object, array, string, number, integer, boolean, null)
+- `ref` (str | None): The `$ref` string when this schema is a reference
+- `type` (str | list[str] | None): Schema type; OpenAPI 3.1 allows type arrays like `["string", "null"]`
+- `format` (str | None): Type format (date-time, uuid, int64, etc.)
 - `title` (str | None): Schema title
 - `description` (str | None): Schema description
 - `properties` (dict[str, Schema]): Object properties (for type=object)
 - `required` (list[str]): Required property names
 - `items` (Schema | None): Array item schema (for type=array)
+- `enum` (list | None): Allowed values
+- `default` / `const`: Default and constant values (see `has_default` / `has_const`)
+- `deprecated` (bool): Whether the schema is deprecated
+- `nullable` (bool | None): OpenAPI 3.0 nullable keyword
+- `read_only` / `write_only` (bool | None): readOnly / writeOnly keywords
+- `example` / `examples`: Example values
+- `discriminator` (Discriminator | None): Discriminator for oneOf/anyOf composition
+- `additional_properties` (Schema | bool | None): additionalProperties keyword
 - `all_of` (list[Schema] | None): allOf composition
 - `one_of` (list[Schema] | None): oneOf composition
 - `any_of` (list[Schema] | None): anyOf composition
 - `not_` (Schema | None): not composition
+- Validation constraints: `minimum`, `maximum`, `exclusive_minimum`, `exclusive_maximum`, `multiple_of`, `min_length`, `max_length`, `pattern`, `min_items`, `max_items`, `unique_items`, `min_properties`, `max_properties`
 
-**Note:** Schema models allow extra fields to support the full JSON Schema vocabulary (like format, enum, minimum, maximum, pattern, etc.)
+**Key Properties:**
+
+- `types` (list[str]): Always-a-list view of `type` (empty list when unset)
+- `primary_type` (str | None): First non-`"null"` type
+- `is_nullable` (bool): True if the schema accepts null - unifies the 3.0 `nullable` keyword, 3.1 type arrays containing `"null"`, and anyOf/oneOf with a `{"type": "null"}` member
+- `has_default` / `has_const` (bool): True when the keyword is explicitly declared (distinguishes `default: null` from no default)
+
+**Note:** Schema models still allow extra fields, so the rest of the JSON Schema vocabulary (prefixItems, patternProperties, etc.) and vendor extensions remain available via `model_extra`.
 
 **Example:**
 
@@ -152,13 +172,35 @@ print(f"Required: {user_schema.required}")
 
 # Explore properties
 for prop_name, prop_schema in user_schema.properties.items():
-    print(f"  {prop_name}: {prop_schema.type}")
+    print(f"  {prop_name}: {prop_schema.primary_type}")
+    if prop_schema.is_nullable:
+        print("    (nullable)")
     if prop_name in user_schema.required:
-        print(f"    (required)")
+        print("    (required)")
 
-# Access additional JSON Schema fields
-if hasattr(user_schema, 'format'):
-    print(f"Format: {user_schema.format}")
+# Typed JSON Schema fields
+print(f"Format: {user_schema.format}")
+if user_schema.enum:
+    print(f"Allowed values: {user_schema.enum}")
+```
+
+### Discriminator
+
+Represents an OpenAPI Discriminator Object, used with oneOf/anyOf/allOf composition.
+
+**Key Attributes:**
+
+- `property_name` (str): The property whose value selects the matching schema
+- `mapping` (dict[str, str]): Mapping of property values to schema names or references
+
+**Example:**
+
+```python
+pet = spec.components.schemas.get("Pet")
+if pet.discriminator:
+    print(f"Discriminated by: {pet.discriminator.property_name}")
+    for value, target in pet.discriminator.mapping.items():
+        print(f"  {value} -> {target}")
 ```
 
 ### Components
@@ -210,16 +252,19 @@ Container for all API paths.
 **Key Methods:**
 
 - `all_operations()`: Generator yielding all operations across all paths
+- Iteration yields `(path, PathItem)` pairs; `len(spec.paths)` returns the number of paths
 
 **Example:**
 
 ```python
 print(spec.paths)  # <Paths: 5 paths, 12 operations [/users, /users/{id}, ...]>
 
-# Iterate paths
-for path_str, path_item in spec.paths.items.items():
+# Iterate paths directly
+for path_str, path_item in spec.paths:
     print(f"Path: {path_str}")
-    
+
+print(f"{len(spec.paths)} paths")
+
 # Get all operations
 for operation in spec.paths.all_operations():
     print(f"{operation.method.upper()} {operation.path}")

--- a/docs/references.md
+++ b/docs/references.md
@@ -287,18 +287,21 @@ Check if a reference creates a circular dependency.
 
 ## Best Practices
 
-1. **Check for references before accessing**: Use `Reference.is_reference()` to check if data contains a $ref
+1. **Check for references before accessing**: Use the typed `ref` field (`schema.ref`, `parameter.ref`, etc.) or `Reference.is_reference()` for raw dicts
 2. **Handle circular references**: Use `is_circular_reference()` before full resolution
-3. **Cache resolved references**: If resolving the same reference multiple times, cache the results
-4. **Validate references**: Verify that all references in your spec can be resolved
+3. **Validate references**: Verify that all references in your spec can be resolved
+
+Resolution behavior notes:
+
+- `OpenAPISpec.resolve_reference()` caches results per spec: resolving the same reference twice returns the same object.
+- When a reference path cannot be found, the error message includes the available keys at the failure point and a did-you-mean suggestion for close matches.
 
 ## Limitations
 
 Current limitations (we'll address these in future versions):
 
 - External references (file paths, URLs) are not yet supported
-- `operationRef` in Link Objects is not yet implemented
-- `mapping` in Discriminator Objects is not yet implemented
+- `operationRef` in Link Objects is parsed (`Link.operation_ref`) but not resolved to an Operation
 - Dynamic references (`$dynamicRef`) from JSON Schema 2020-12 / OAS 3.1 are not yet supported
 
 ## See Also

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cicerone"
-version = "0.3.0"
+version = "0.4.0"
 description = "Turn OpenAPI schemas into Pydantic models"
 authors = [{ name = "Paul Hallett", email = "paulandrewhallett@gmail.com" }]
 license = { text = "MIT" }

--- a/tests/spec/test_additional_models.py
+++ b/tests/spec/test_additional_models.py
@@ -92,7 +92,7 @@ class TestLink:
             "description": "Link to user",
         }
         link = cicerone_spec.Link.from_dict(data)
-        assert link.operationId == "getUser"
+        assert link.operation_id == "getUser"
         assert link.description == "Link to user"
         assert "userId" in link.parameters
 

--- a/tests/spec/test_additional_models.py
+++ b/tests/spec/test_additional_models.py
@@ -15,7 +15,9 @@ class TestMediaType:
             "example": {"id": "123"},
         }
         media_type = cicerone_spec.MediaType.from_dict(data)
-        assert media_type.schema_ == {"type": "object", "properties": {"id": {"type": "string"}}}
+        assert isinstance(media_type.schema_, cicerone_spec.Schema)
+        assert media_type.schema_.type == "object"
+        assert media_type.schema_.properties["id"].type == "string"
         assert media_type.example == {"id": "123"}
 
     def test_media_type_with_examples(self):

--- a/tests/spec/test_discriminator.py
+++ b/tests/spec/test_discriminator.py
@@ -49,6 +49,7 @@ class TestSchemaDiscriminator:
         )
         assert isinstance(schema.discriminator, cicerone_spec.Discriminator)
         assert schema.discriminator.property_name == "petType"
+        assert schema.one_of is not None
         assert schema.one_of[0].ref == "#/components/schemas/Dog"
 
     def test_schema_without_discriminator(self):

--- a/tests/spec/test_discriminator.py
+++ b/tests/spec/test_discriminator.py
@@ -1,0 +1,84 @@
+"""Tests for the Discriminator model.
+
+References:
+- OpenAPI 3.x Discriminator Object: https://spec.openapis.org/oas/v3.1.0#discriminator-object
+"""
+
+from __future__ import annotations
+
+from cicerone import spec as cicerone_spec
+from cicerone.parse import parse_spec_from_dict
+
+
+class TestDiscriminator:
+    def test_from_dict_with_property_name(self):
+        discriminator = cicerone_spec.Discriminator.from_dict({"propertyName": "petType"})
+        assert discriminator.property_name == "petType"
+        assert discriminator.mapping == {}
+
+    def test_from_dict_with_mapping(self):
+        discriminator = cicerone_spec.Discriminator.from_dict(
+            {
+                "propertyName": "petType",
+                "mapping": {
+                    "dog": "#/components/schemas/Dog",
+                    "cat": "#/components/schemas/Cat",
+                },
+            }
+        )
+        assert discriminator.property_name == "petType"
+        assert discriminator.mapping["dog"] == "#/components/schemas/Dog"
+        assert discriminator.mapping["cat"] == "#/components/schemas/Cat"
+
+    def test_str_representation(self):
+        discriminator = cicerone_spec.Discriminator.from_dict(
+            {"propertyName": "petType", "mapping": {"dog": "#/components/schemas/Dog"}}
+        )
+        text = str(discriminator)
+        assert "petType" in text
+        assert "1 mapping" in text
+
+
+class TestSchemaDiscriminator:
+    def test_schema_discriminator_is_typed(self):
+        schema = cicerone_spec.Schema.from_dict(
+            {
+                "oneOf": [{"$ref": "#/components/schemas/Dog"}, {"$ref": "#/components/schemas/Cat"}],
+                "discriminator": {"propertyName": "petType"},
+            }
+        )
+        assert isinstance(schema.discriminator, cicerone_spec.Discriminator)
+        assert schema.discriminator.property_name == "petType"
+        assert schema.one_of[0].ref == "#/components/schemas/Dog"
+
+    def test_schema_without_discriminator(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "object"})
+        assert schema.discriminator is None
+
+    def test_discriminator_in_parsed_spec(self):
+        spec = parse_spec_from_dict(
+            {
+                "openapi": "3.0.0",
+                "info": {"title": "Pets", "version": "1.0.0"},
+                "paths": {},
+                "components": {
+                    "schemas": {
+                        "Pet": {
+                            "oneOf": [
+                                {"$ref": "#/components/schemas/Dog"},
+                                {"$ref": "#/components/schemas/Cat"},
+                            ],
+                            "discriminator": {
+                                "propertyName": "petType",
+                                "mapping": {"dog": "#/components/schemas/Dog"},
+                            },
+                        },
+                        "Dog": {"type": "object", "properties": {"petType": {"type": "string"}}},
+                        "Cat": {"type": "object", "properties": {"petType": {"type": "string"}}},
+                    }
+                },
+            }
+        )
+        pet = spec.components.schemas["Pet"]
+        assert pet.discriminator.property_name == "petType"
+        assert pet.discriminator.mapping == {"dog": "#/components/schemas/Dog"}

--- a/tests/spec/test_lenient_parsing.py
+++ b/tests/spec/test_lenient_parsing.py
@@ -1,0 +1,93 @@
+"""Tests for lenient parsing of malformed real-world specs.
+
+Before 0.4.0, keywords like ``pattern`` or ``enum`` lived in ``model_extra``
+and were never validated, so malformed values (e.g. a YAML float for
+``pattern``) parsed fine. Promoting them to typed fields must not reject
+documents 0.3.0 accepted: when an optional scalar field fails validation, the
+field falls back to its default and the raw value remains available via
+``model_extra`` (where mirrored) and ``spec.raw``.
+"""
+
+from __future__ import annotations
+
+from cicerone import spec as cicerone_spec
+
+
+class TestSchemaLenientScalars:
+    def test_non_string_pattern_falls_back(self):
+        # Seen in the wild: YAML parses `pattern: 0.0` as a float
+        schema = cicerone_spec.Schema.from_dict({"type": "string", "pattern": 0.0})
+        assert schema.pattern is None
+        assert schema.model_extra is not None
+        assert schema.model_extra["pattern"] == 0.0
+
+    def test_non_list_enum_falls_back(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "string", "enum": "red"})
+        assert schema.enum is None
+        assert schema.model_extra is not None
+        assert schema.model_extra["enum"] == "red"
+
+    def test_swagger2_style_boolean_required_falls_back(self):
+        # Swagger 2.0 style `required: true` on a property-level schema
+        schema = cicerone_spec.Schema.from_dict({"type": "string", "required": True})
+        assert schema.required == []
+
+    def test_non_numeric_minimum_falls_back(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "number", "minimum": "zero"})
+        assert schema.minimum is None
+
+    def test_non_string_format_falls_back(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "string", "format": 64})
+        assert schema.format is None
+
+    def test_valid_values_still_validated(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "string", "pattern": "^[a-z]+$", "minLength": 1})
+        assert schema.pattern == "^[a-z]+$"
+        assert schema.min_length == 1
+
+
+class TestOperationLenientParsing:
+    def test_malformed_inline_response_description(self):
+        # 0.3.0 stored responses as raw dicts, so a non-string description
+        # parsed fine; typed parsing must not reject the document
+        data = {"responses": {"200": {"description": 200}}}
+        operation = cicerone_spec.Operation.from_dict("GET", "/users", data)
+        assert operation.responses["200"].description is None
+
+    def test_malformed_inline_parameter_style(self):
+        data = {"parameters": [{"name": "q", "in": "query", "style": 123}]}
+        operation = cicerone_spec.Operation.from_dict("GET", "/users", data)
+        assert operation.parameters[0].name == "q"
+        assert operation.parameters[0].style is None
+
+    def test_malformed_operation_summary(self):
+        operation = cicerone_spec.Operation.from_dict("GET", "/users", {"summary": ["not", "a", "string"]})
+        assert operation.summary is None
+
+    def test_malformed_tags(self):
+        operation = cicerone_spec.Operation.from_dict("GET", "/users", {"tags": "user"})
+        assert operation.tags == []
+
+
+class TestCollectionGuards:
+    def test_non_dict_collection_items_skipped(self):
+        # A malformed header entry must not crash parsing of the response
+        response = cicerone_spec.Response.from_dict(
+            {
+                "description": "OK",
+                "headers": {"X-Good": {"schema": {"type": "integer"}}, "X-Bad": "not-a-header"},
+            }
+        )
+        assert "X-Good" in response.headers
+        assert "X-Bad" not in response.headers
+
+
+class TestHeaderAndRequestBodyLenient:
+    def test_malformed_header_description(self):
+        header = cicerone_spec.Header.from_dict({"description": {"text": "wrong shape"}})
+        assert header.description is None
+
+    def test_malformed_request_body_description(self):
+        request_body = cicerone_spec.RequestBody.from_dict({"description": 123, "required": "yes-please"})
+        assert request_body.description is None
+        assert request_body.required is False

--- a/tests/spec/test_lenient_parsing.py
+++ b/tests/spec/test_lenient_parsing.py
@@ -70,6 +70,30 @@ class TestOperationLenientParsing:
 
 
 class TestCollectionGuards:
+    def test_non_string_property_keys_coerced(self):
+        # YAML parses unquoted `no:` as boolean False; coerce keys to str
+        schema = cicerone_spec.Schema.from_dict(
+            {"type": "object", "properties": {False: {"type": "string"}, "name": {"type": "string"}}}
+        )
+        assert "False" in schema.properties
+        assert "name" in schema.properties
+
+    def test_boolean_properties_value_skipped(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "object", "properties": True})
+        assert schema.properties == {}
+
+    def test_non_string_header_keys_coerced(self):
+        response = cicerone_spec.Response.from_dict(
+            {"description": "OK", "headers": {False: {"schema": {"type": "string"}}}}
+        )
+        assert "False" in response.headers
+
+    def test_malformed_example_summary(self):
+        # Seen in the wild: YAML bool or date where a summary string belongs
+        example = cicerone_spec.Example.from_dict({"summary": False, "value": 1})
+        assert example.summary is None
+        assert example.value == 1
+
     def test_non_dict_collection_items_skipped(self):
         # A malformed header entry must not crash parsing of the response
         response = cicerone_spec.Response.from_dict(

--- a/tests/spec/test_path_item.py
+++ b/tests/spec/test_path_item.py
@@ -63,16 +63,21 @@ class TestPathItem:
         get_params = path_item.operations["get"].parameters
         assert len(get_params) == 3
         # Path-level parameters should come first
-        assert get_params[0]["name"] == "request-id"
-        assert get_params[1]["$ref"] == "#/components/parameters/api-version"
+        assert get_params[0].name == "request-id"
+        assert get_params[1].ref == "#/components/parameters/api-version"
         # Operation-level parameters should come after
-        assert get_params[2]["name"] == "x-customer-ip"
+        assert get_params[2].name == "x-customer-ip"
 
         # POST operation should have only path-level parameters
         post_params = path_item.operations["post"].parameters
         assert len(post_params) == 2
-        assert post_params[0]["name"] == "request-id"
-        assert post_params[1]["$ref"] == "#/components/parameters/api-version"
+        assert post_params[0].name == "request-id"
+        assert post_params[1].ref == "#/components/parameters/api-version"
+
+        # Path-level parameters are also available as typed objects on the PathItem
+        assert len(path_item.parameters) == 2
+        assert path_item.parameters[0].name == "request-id"
+        assert path_item.parameters[1].ref == "#/components/parameters/api-version"
 
     def test_path_level_parameters_with_no_operations_parameters(self):
         """Test path-level parameters when operations don't define their own."""
@@ -85,9 +90,9 @@ class TestPathItem:
 
         # Both operations should have the path-level parameter
         assert len(path_item.operations["get"].parameters) == 1
-        assert path_item.operations["get"].parameters[0]["name"] == "api-key"
+        assert path_item.operations["get"].parameters[0].name == "api-key"
         assert len(path_item.operations["post"].parameters) == 1
-        assert path_item.operations["post"].parameters[0]["name"] == "api-key"
+        assert path_item.operations["post"].parameters[0].name == "api-key"
 
     def test_operations_without_path_level_parameters(self):
         """Test that operations without path-level parameters work normally."""
@@ -101,4 +106,4 @@ class TestPathItem:
 
         # Operation should only have its own parameter
         assert len(path_item.operations["get"].parameters) == 1
-        assert path_item.operations["get"].parameters[0]["name"] == "user-id"
+        assert path_item.operations["get"].parameters[0].name == "user-id"

--- a/tests/spec/test_query_api.py
+++ b/tests/spec/test_query_api.py
@@ -1,0 +1,121 @@
+"""Tests for the spec query conveniences added in 0.4.0.
+
+These encode the access patterns consumers (like clientele) need:
+tag-based operation lookup, direct Paths iteration, cached reference
+resolution, and helpful broken-reference errors.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cicerone import spec as cicerone_spec
+from cicerone.parse import parse_spec_from_dict
+
+
+@pytest.fixture
+def tagged_spec() -> cicerone_spec.OpenAPISpec:
+    return parse_spec_from_dict(
+        {
+            "openapi": "3.0.0",
+            "info": {"title": "Test", "version": "1.0.0"},
+            "paths": {
+                "/users": {
+                    "get": {"operationId": "listUsers", "tags": ["users"]},
+                    "post": {"operationId": "createUser", "tags": ["users", "admin"]},
+                },
+                "/pets": {
+                    "get": {"operationId": "listPets", "tags": ["pets"]},
+                },
+                "/health": {
+                    "get": {"operationId": "healthCheck"},
+                },
+            },
+            "components": {
+                "schemas": {
+                    "User": {"type": "object", "properties": {"name": {"type": "string"}}},
+                    "UserList": {"type": "array", "items": {"$ref": "#/components/schemas/User"}},
+                }
+            },
+        }
+    )
+
+
+class TestOperationsByTag:
+    def test_operations_by_tag(self, tagged_spec):
+        users_ops = list(tagged_spec.operations_by_tag("users"))
+        assert {op.operation_id for op in users_ops} == {"listUsers", "createUser"}
+
+    def test_operation_with_multiple_tags_found_under_each(self, tagged_spec):
+        admin_ops = list(tagged_spec.operations_by_tag("admin"))
+        assert [op.operation_id for op in admin_ops] == ["createUser"]
+
+    def test_unknown_tag_yields_nothing(self, tagged_spec):
+        assert list(tagged_spec.operations_by_tag("nonexistent")) == []
+
+    def test_tags_to_operations(self, tagged_spec):
+        mapping = tagged_spec.tags_to_operations()
+        assert {op.operation_id for op in mapping["users"]} == {"listUsers", "createUser"}
+        assert [op.operation_id for op in mapping["pets"]] == ["listPets"]
+        assert [op.operation_id for op in mapping["admin"]] == ["createUser"]
+        # Untagged operations are not included
+        all_ids = {op.operation_id for ops in mapping.values() for op in ops}
+        assert "healthCheck" not in all_ids
+
+
+class TestPathsIteration:
+    def test_iterating_paths_yields_path_and_item(self, tagged_spec):
+        entries = dict(tagged_spec.paths)
+        assert set(entries.keys()) == {"/users", "/pets", "/health"}
+        assert isinstance(entries["/users"], cicerone_spec.PathItem)
+
+    def test_len(self, tagged_spec):
+        assert len(tagged_spec.paths) == 3
+
+
+class TestCachedResolution:
+    def test_repeated_resolution_returns_same_object(self, tagged_spec):
+        first = tagged_spec.resolve_reference("#/components/schemas/User")
+        second = tagged_spec.resolve_reference("#/components/schemas/User")
+        assert first is second
+
+    def test_follow_nested_flag_cached_separately(self, tagged_spec):
+        followed = tagged_spec.resolve_reference("#/components/schemas/UserList", follow_nested=True)
+        assert isinstance(followed.items, cicerone_spec.Schema)
+        assert followed.items.properties["name"].type == "string"
+
+    def test_circular_references_still_detected(self):
+        spec = parse_spec_from_dict(
+            {
+                "openapi": "3.0.0",
+                "info": {"title": "Test", "version": "1.0.0"},
+                "paths": {},
+                "components": {
+                    "schemas": {
+                        "Node": {
+                            "type": "object",
+                            "properties": {"next": {"$ref": "#/components/schemas/Node"}},
+                        }
+                    }
+                },
+            }
+        )
+        # Self-referential schemas resolve without infinite recursion
+        node = spec.resolve_reference("#/components/schemas/Node")
+        assert isinstance(node, cicerone_spec.Schema)
+
+
+class TestBrokenReferenceErrors:
+    def test_error_includes_suggestion_for_close_match(self, tagged_spec):
+        with pytest.raises(ValueError) as exc_info:
+            tagged_spec.resolve_reference("#/components/schemas/Usr")
+        message = str(exc_info.value)
+        assert "#/components/schemas/Usr" in message
+        # A did-you-mean suggestion pointing at the close match
+        assert "User" in message
+
+    def test_error_lists_available_keys(self, tagged_spec):
+        with pytest.raises(ValueError) as exc_info:
+            tagged_spec.resolve_reference("#/components/schemas/Banana")
+        message = str(exc_info.value)
+        assert "User" in message or "Available" in message

--- a/tests/spec/test_schema_openapi31.py
+++ b/tests/spec/test_schema_openapi31.py
@@ -1,0 +1,121 @@
+"""Tests for native OpenAPI 3.1 type-array support on Schema.
+
+OpenAPI 3.1 replaced the 3.0 ``nullable`` keyword with JSON Schema type arrays
+(e.g. ``type: ["string", "null"]``). These tests encode the uniform view that
+consumers can use without pre-normalizing 3.1 specs to 3.0.
+"""
+
+from __future__ import annotations
+
+from cicerone import spec as cicerone_spec
+from cicerone.parse import parse_spec_from_dict
+
+
+class TestTypesProperty:
+    """Schema.types is an always-a-list view of the type keyword."""
+
+    def test_single_type(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "string"})
+        assert schema.types == ["string"]
+
+    def test_type_array(self):
+        schema = cicerone_spec.Schema.from_dict({"type": ["string", "null"]})
+        assert schema.types == ["string", "null"]
+
+    def test_unset_type(self):
+        schema = cicerone_spec.Schema.from_dict({})
+        assert schema.types == []
+
+
+class TestPrimaryTypeProperty:
+    """Schema.primary_type is the first non-null type."""
+
+    def test_single_type(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "integer"})
+        assert schema.primary_type == "integer"
+
+    def test_type_array_with_null(self):
+        schema = cicerone_spec.Schema.from_dict({"type": ["string", "null"]})
+        assert schema.primary_type == "string"
+
+    def test_null_first_in_array(self):
+        schema = cicerone_spec.Schema.from_dict({"type": ["null", "number"]})
+        assert schema.primary_type == "number"
+
+    def test_only_null(self):
+        schema = cicerone_spec.Schema.from_dict({"type": ["null"]})
+        assert schema.primary_type is None
+
+    def test_unset_type(self):
+        schema = cicerone_spec.Schema.from_dict({})
+        assert schema.primary_type is None
+
+
+class TestIsNullableProperty:
+    """Schema.is_nullable unifies 3.0 nullable and 3.1 type arrays."""
+
+    def test_openapi_30_nullable_keyword(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "string", "nullable": True})
+        assert schema.is_nullable is True
+
+    def test_openapi_30_not_nullable(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "string"})
+        assert schema.is_nullable is False
+
+    def test_openapi_31_type_array_with_null(self):
+        schema = cicerone_spec.Schema.from_dict({"type": ["string", "null"]})
+        assert schema.is_nullable is True
+
+    def test_openapi_31_type_array_without_null(self):
+        schema = cicerone_spec.Schema.from_dict({"type": ["string", "integer"]})
+        assert schema.is_nullable is False
+
+    def test_openapi_31_null_only_type(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "null"})
+        assert schema.is_nullable is True
+
+    def test_any_of_with_null_member(self):
+        schema = cicerone_spec.Schema.from_dict({"anyOf": [{"type": "string"}, {"type": "null"}]})
+        assert schema.is_nullable is True
+
+    def test_one_of_with_null_member(self):
+        schema = cicerone_spec.Schema.from_dict({"oneOf": [{"$ref": "#/components/schemas/User"}, {"type": "null"}]})
+        assert schema.is_nullable is True
+
+    def test_composition_without_null_member(self):
+        schema = cicerone_spec.Schema.from_dict({"oneOf": [{"type": "string"}, {"type": "integer"}]})
+        assert schema.is_nullable is False
+
+
+class TestEndToEnd31Parsing:
+    """A 3.1 spec with type arrays parses without pre-normalization."""
+
+    def test_31_spec_with_type_arrays(self):
+        spec = parse_spec_from_dict(
+            {
+                "openapi": "3.1.0",
+                "info": {"title": "Test", "version": "1.0.0"},
+                "paths": {},
+                "components": {
+                    "schemas": {
+                        "User": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "nickname": {"type": ["string", "null"]},
+                                "age": {"type": ["integer", "null"]},
+                            },
+                            "required": ["name"],
+                        }
+                    }
+                },
+            }
+        )
+        user = spec.components.schemas["User"]
+        assert user.properties["name"].is_nullable is False
+        nickname = user.properties["nickname"]
+        assert nickname.is_nullable is True
+        assert nickname.primary_type == "string"
+        age = user.properties["age"]
+        assert age.is_nullable is True
+        assert age.primary_type == "integer"

--- a/tests/spec/test_typed_fields.py
+++ b/tests/spec/test_typed_fields.py
@@ -131,6 +131,21 @@ class TestSchemaTypedFields:
         schema = cicerone_spec.Schema.from_dict({"type": "object"})
         assert schema.additional_properties is None
 
+    def test_prefix_items_tuples(self):
+        # JSON Schema tuple validation (OpenAPI 3.1), see PR #30
+        schema = cicerone_spec.Schema.from_dict(
+            {"type": "array", "prefixItems": [{"type": "string"}, {"type": "integer"}]}
+        )
+        assert schema.prefix_items is not None
+        assert schema.prefix_items[0].type == "string"
+        assert schema.prefix_items[1].type == "integer"
+        assert schema.model_extra is not None
+        assert schema.model_extra["prefixItems"] == [{"type": "string"}, {"type": "integer"}]
+
+    def test_prefix_items_absent(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "array", "items": {"type": "string"}})
+        assert schema.prefix_items is None
+
     def test_boolean_items_does_not_crash(self):
         # JSON Schema allows boolean schemas; cicerone skips them rather than crashing
         schema = cicerone_spec.Schema.from_dict({"type": "array", "items": True})

--- a/tests/spec/test_typed_fields.py
+++ b/tests/spec/test_typed_fields.py
@@ -1,0 +1,476 @@
+"""Tests for the typed first-class fields introduced in 0.4.0.
+
+These tests encode the contract that spec-defined fields (previously only
+available via ``model_extra``) are now proper typed model fields, while raw
+values remain mirrored in ``model_extra`` for backwards compatibility
+(the mirroring is deprecated and will be removed in 0.5.0).
+"""
+
+from __future__ import annotations
+
+from cicerone import spec as cicerone_spec
+from cicerone.parse import parse_spec_from_dict
+
+
+class TestSchemaTypedFields:
+    """Schema exposes JSON Schema / OpenAPI keywords as typed fields."""
+
+    def test_ref_field(self):
+        schema = cicerone_spec.Schema.from_dict({"$ref": "#/components/schemas/User"})
+        assert schema.ref == "#/components/schemas/User"
+
+    def test_ref_defaults_to_none(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "string"})
+        assert schema.ref is None
+
+    def test_format_field(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "string", "format": "date-time"})
+        assert schema.format == "date-time"
+
+    def test_enum_field(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "string", "enum": ["red", "green", "blue"]})
+        assert schema.enum == ["red", "green", "blue"]
+
+    def test_enum_defaults_to_none(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "string"})
+        assert schema.enum is None
+
+    def test_default_field(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "integer", "default": 42})
+        assert schema.default == 42
+        assert schema.has_default
+
+    def test_default_null_is_distinguished_from_absent(self):
+        with_null_default = cicerone_spec.Schema.from_dict({"type": "string", "default": None})
+        without_default = cicerone_spec.Schema.from_dict({"type": "string"})
+        assert with_null_default.has_default
+        assert with_null_default.default is None
+        assert not without_default.has_default
+
+    def test_const_field(self):
+        schema = cicerone_spec.Schema.from_dict({"const": "fixed-value"})
+        assert schema.const == "fixed-value"
+        assert schema.has_const
+
+    def test_const_null_is_distinguished_from_absent(self):
+        with_null_const = cicerone_spec.Schema.from_dict({"const": None})
+        without_const = cicerone_spec.Schema.from_dict({"type": "string"})
+        assert with_null_const.has_const
+        assert not without_const.has_const
+
+    def test_deprecated_field(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "string", "deprecated": True})
+        assert schema.deprecated is True
+        assert cicerone_spec.Schema.from_dict({"type": "string"}).deprecated is False
+
+    def test_nullable_field(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "string", "nullable": True})
+        assert schema.nullable is True
+        assert cicerone_spec.Schema.from_dict({"type": "string"}).nullable is None
+
+    def test_read_only_and_write_only(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "string", "readOnly": True, "writeOnly": False})
+        assert schema.read_only is True
+        assert schema.write_only is False
+
+    def test_example_field(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "string", "example": "hello"})
+        assert schema.example == "hello"
+
+    def test_numeric_constraints(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "number", "minimum": 0, "maximum": 100, "multipleOf": 0.5})
+        assert schema.minimum == 0
+        assert schema.maximum == 100
+        assert schema.multiple_of == 0.5
+
+    def test_exclusive_bounds_as_bool_openapi_30(self):
+        schema = cicerone_spec.Schema.from_dict(
+            {"type": "number", "minimum": 0, "exclusiveMinimum": True, "exclusiveMaximum": False}
+        )
+        assert schema.exclusive_minimum is True
+        assert schema.exclusive_maximum is False
+
+    def test_exclusive_bounds_as_number_openapi_31(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "number", "exclusiveMinimum": 0, "exclusiveMaximum": 10})
+        assert schema.exclusive_minimum == 0
+        assert schema.exclusive_maximum == 10
+
+    def test_string_constraints(self):
+        schema = cicerone_spec.Schema.from_dict(
+            {"type": "string", "minLength": 1, "maxLength": 64, "pattern": "^[a-z]+$"}
+        )
+        assert schema.min_length == 1
+        assert schema.max_length == 64
+        assert schema.pattern == "^[a-z]+$"
+
+    def test_array_constraints(self):
+        schema = cicerone_spec.Schema.from_dict(
+            {"type": "array", "items": {"type": "string"}, "minItems": 1, "maxItems": 10, "uniqueItems": True}
+        )
+        assert schema.min_items == 1
+        assert schema.max_items == 10
+        assert schema.unique_items is True
+
+    def test_object_constraints(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "object", "minProperties": 1, "maxProperties": 5})
+        assert schema.min_properties == 1
+        assert schema.max_properties == 5
+
+    def test_additional_properties_as_schema(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "object", "additionalProperties": {"type": "string"}})
+        assert isinstance(schema.additional_properties, cicerone_spec.Schema)
+        assert schema.additional_properties.type == "string"
+
+    def test_additional_properties_as_bool(self):
+        closed = cicerone_spec.Schema.from_dict({"type": "object", "additionalProperties": False})
+        open_ = cicerone_spec.Schema.from_dict({"type": "object", "additionalProperties": True})
+        assert closed.additional_properties is False
+        assert open_.additional_properties is True
+
+    def test_additional_properties_absent(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "object"})
+        assert schema.additional_properties is None
+
+    def test_boolean_items_does_not_crash(self):
+        # JSON Schema allows boolean schemas; cicerone skips them rather than crashing
+        schema = cicerone_spec.Schema.from_dict({"type": "array", "items": True})
+        assert schema.items is None
+
+    def test_construction_by_field_name(self):
+        # populate_by_name allows programmatic construction with snake_case names
+        schema = cicerone_spec.Schema(ref="#/components/schemas/User", min_length=3)
+        assert schema.ref == "#/components/schemas/User"
+        assert schema.min_length == 3
+
+
+class TestSchemaExtrasMirroring:
+    """Promoted keys remain mirrored in model_extra until 0.5.0."""
+
+    def test_scalar_keys_mirrored(self):
+        data = {
+            "$ref": "#/components/schemas/User",
+            "enum": ["a", "b"],
+            "default": "a",
+            "const": "a",
+            "deprecated": True,
+            "format": "uuid",
+        }
+        schema = cicerone_spec.Schema.from_dict(data)
+        extra = schema.model_extra
+        assert extra["$ref"] == "#/components/schemas/User"
+        assert extra["enum"] == ["a", "b"]
+        assert extra["default"] == "a"
+        assert extra["const"] == "a"
+        assert extra["deprecated"] is True
+        assert extra["format"] == "uuid"
+
+    def test_mirrored_values_are_raw_not_models(self):
+        data = {"discriminator": {"propertyName": "petType"}, "additionalProperties": {"type": "string"}}
+        schema = cicerone_spec.Schema.from_dict(data)
+        assert schema.model_extra["discriminator"] == {"propertyName": "petType"}
+        assert schema.model_extra["additionalProperties"] == {"type": "string"}
+
+    def test_absent_keys_not_mirrored(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "string"})
+        assert "enum" not in schema.model_extra
+        assert "$ref" not in schema.model_extra
+
+    def test_vendor_extensions_still_in_extras(self):
+        schema = cicerone_spec.Schema.from_dict({"type": "string", "x-internal": True})
+        assert schema.model_extra["x-internal"] is True
+
+
+class TestOperationTypedFields:
+    """Operation exposes requestBody, security, callbacks, etc. as typed fields."""
+
+    def test_request_body_typed(self):
+        data = {
+            "operationId": "createUser",
+            "requestBody": {
+                "required": True,
+                "content": {"application/json": {"schema": {"type": "object"}}},
+            },
+            "responses": {"201": {"description": "Created"}},
+        }
+        operation = cicerone_spec.Operation.from_dict("POST", "/users", data)
+        assert isinstance(operation.request_body, cicerone_spec.RequestBody)
+        assert operation.request_body.required is True
+        media_type = operation.request_body.content["application/json"]
+        assert isinstance(media_type.schema_, cicerone_spec.Schema)
+        assert media_type.schema_.type == "object"
+
+    def test_request_body_defaults_to_none(self):
+        operation = cicerone_spec.Operation.from_dict("GET", "/users", {"operationId": "listUsers"})
+        assert operation.request_body is None
+
+    def test_responses_typed(self):
+        data = {
+            "responses": {
+                "200": {
+                    "description": "OK",
+                    "content": {"application/json": {"schema": {"$ref": "#/components/schemas/User"}}},
+                },
+                "404": {"$ref": "#/components/responses/NotFound"},
+            }
+        }
+        operation = cicerone_spec.Operation.from_dict("GET", "/users/{id}", data)
+        ok = operation.responses["200"]
+        assert isinstance(ok, cicerone_spec.Response)
+        assert ok.description == "OK"
+        assert ok.content["application/json"].schema_.ref == "#/components/schemas/User"
+        not_found = operation.responses["404"]
+        assert isinstance(not_found, cicerone_spec.Response)
+        assert not_found.ref == "#/components/responses/NotFound"
+
+    def test_parameters_typed(self):
+        data = {
+            "parameters": [
+                {"name": "id", "in": "path", "required": True, "schema": {"type": "integer"}},
+                {"$ref": "#/components/parameters/PageSize"},
+            ]
+        }
+        operation = cicerone_spec.Operation.from_dict("GET", "/users/{id}", data)
+        assert all(isinstance(p, cicerone_spec.Parameter) for p in operation.parameters)
+        assert operation.parameters[0].name == "id"
+        assert operation.parameters[0].in_ == "path"
+        assert operation.parameters[0].schema_.type == "integer"
+        assert operation.parameters[1].ref == "#/components/parameters/PageSize"
+
+    def test_security_none_means_inherit(self):
+        operation = cicerone_spec.Operation.from_dict("GET", "/users", {})
+        assert operation.security is None
+
+    def test_security_empty_list_means_no_security(self):
+        operation = cicerone_spec.Operation.from_dict("GET", "/health", {"security": []})
+        assert operation.security == []
+
+    def test_security_requirements(self):
+        data = {"security": [{"oauth2": ["read:users"]}, {"apiKey": []}]}
+        operation = cicerone_spec.Operation.from_dict("GET", "/users", data)
+        assert operation.security == [{"oauth2": ["read:users"]}, {"apiKey": []}]
+
+    def test_deprecated_field(self):
+        operation = cicerone_spec.Operation.from_dict("GET", "/old", {"deprecated": True})
+        assert operation.deprecated is True
+        assert cicerone_spec.Operation.from_dict("GET", "/new", {}).deprecated is False
+
+    def test_callbacks_typed(self):
+        data = {
+            "callbacks": {
+                "onEvent": {
+                    "{$request.body#/callbackUrl}": {
+                        "post": {"responses": {"200": {"description": "OK"}}},
+                    }
+                }
+            }
+        }
+        operation = cicerone_spec.Operation.from_dict("POST", "/subscribe", data)
+        callback = operation.callbacks["onEvent"]
+        assert isinstance(callback, cicerone_spec.Callback)
+        path_item = callback.get("{$request.body#/callbackUrl}")
+        assert path_item is not None
+        assert "post" in path_item.operations
+
+    def test_servers_typed(self):
+        data = {"servers": [{"url": "https://api.example.com/v2"}]}
+        operation = cicerone_spec.Operation.from_dict("GET", "/users", data)
+        assert isinstance(operation.servers[0], cicerone_spec.Server)
+        assert operation.servers[0].url == "https://api.example.com/v2"
+
+    def test_external_docs_typed(self):
+        data = {"externalDocs": {"url": "https://docs.example.com", "description": "More info"}}
+        operation = cicerone_spec.Operation.from_dict("GET", "/users", data)
+        assert isinstance(operation.external_docs, cicerone_spec.ExternalDocumentation)
+        assert operation.external_docs.url == "https://docs.example.com"
+
+    def test_extras_mirroring(self):
+        data = {
+            "requestBody": {"content": {"application/json": {"schema": {"type": "object"}}}},
+            "security": [{"apiKey": []}],
+            "deprecated": True,
+        }
+        operation = cicerone_spec.Operation.from_dict("POST", "/users", data)
+        # Raw values mirrored for pre-0.4.0 consumers (removed in 0.5.0)
+        assert operation.model_extra["requestBody"] == data["requestBody"]
+        assert operation.model_extra["security"] == [{"apiKey": []}]
+        assert operation.model_extra["deprecated"] is True
+
+
+class TestMediaTypeTypedSchema:
+    """MediaType.schema_ is a typed Schema, not a raw dict."""
+
+    def test_schema_is_typed(self):
+        media_type = cicerone_spec.MediaType.from_dict({"schema": {"type": "array", "items": {"type": "string"}}})
+        assert isinstance(media_type.schema_, cicerone_spec.Schema)
+        assert media_type.schema_.type == "array"
+        assert media_type.schema_.items.type == "string"
+
+    def test_ref_schema_is_typed(self):
+        media_type = cicerone_spec.MediaType.from_dict({"schema": {"$ref": "#/components/schemas/User"}})
+        assert isinstance(media_type.schema_, cicerone_spec.Schema)
+        assert media_type.schema_.ref == "#/components/schemas/User"
+
+    def test_missing_schema_is_none(self):
+        media_type = cicerone_spec.MediaType.from_dict({"example": "hello"})
+        assert media_type.schema_ is None
+
+
+class TestParameterTypedFields:
+    def test_ref_field(self):
+        parameter = cicerone_spec.Parameter.from_dict({"$ref": "#/components/parameters/PageSize"})
+        assert parameter.ref == "#/components/parameters/PageSize"
+        assert parameter.model_extra["$ref"] == "#/components/parameters/PageSize"
+
+    def test_deprecated_and_allow_empty_value(self):
+        parameter = cicerone_spec.Parameter.from_dict(
+            {"name": "q", "in": "query", "deprecated": True, "allowEmptyValue": True}
+        )
+        assert parameter.deprecated is True
+        assert parameter.allow_empty_value is True
+
+
+class TestHeaderTypedFields:
+    def test_ref_and_deprecated(self):
+        header = cicerone_spec.Header.from_dict({"$ref": "#/components/headers/RateLimit"})
+        assert header.ref == "#/components/headers/RateLimit"
+        deprecated = cicerone_spec.Header.from_dict({"description": "old", "deprecated": True})
+        assert deprecated.deprecated is True
+
+
+class TestRequestBodyAndResponseRef:
+    def test_request_body_ref(self):
+        request_body = cicerone_spec.RequestBody.from_dict({"$ref": "#/components/requestBodies/UserBody"})
+        assert request_body.ref == "#/components/requestBodies/UserBody"
+
+    def test_response_ref(self):
+        response = cicerone_spec.Response.from_dict({"$ref": "#/components/responses/NotFound"})
+        assert response.ref == "#/components/responses/NotFound"
+
+
+class TestEncodingTypedHeaders:
+    def test_headers_are_typed(self):
+        encoding = cicerone_spec.Encoding.from_dict(
+            {
+                "contentType": "image/png",
+                "headers": {"X-Rate-Limit": {"description": "limit", "schema": {"type": "integer"}}},
+            }
+        )
+        header = encoding.headers["X-Rate-Limit"]
+        assert isinstance(header, cicerone_spec.Header)
+        assert header.description == "limit"
+        assert header.schema_.type == "integer"
+
+
+class TestLinkTypedFields:
+    def test_snake_case_fields(self):
+        link = cicerone_spec.Link.from_dict(
+            {
+                "operationId": "getUser",
+                "operationRef": "#/paths/~1users~1{id}/get",
+                "parameters": {"id": "$response.body#/id"},
+                "server": {"url": "https://api.example.com"},
+            }
+        )
+        assert link.operation_id == "getUser"
+        assert link.operation_ref == "#/paths/~1users~1{id}/get"
+        assert isinstance(link.server, cicerone_spec.Server)
+        assert link.server.url == "https://api.example.com"
+
+    def test_old_camel_case_access_still_works_via_extras(self):
+        link = cicerone_spec.Link.from_dict({"operationId": "getUser"})
+        # Deprecated compat: pre-0.4.0 attribute access (removed in 0.5.0)
+        assert link.operationId == "getUser"
+
+
+class TestPathItemTypedFields:
+    def test_summary_description_and_parameters(self):
+        data = {
+            "summary": "User operations",
+            "description": "Operations on a single user",
+            "parameters": [{"name": "id", "in": "path", "required": True}],
+            "get": {"operationId": "getUser"},
+        }
+        path_item = cicerone_spec.PathItem.from_dict("/users/{id}", data)
+        assert path_item.summary == "User operations"
+        assert path_item.description == "Operations on a single user"
+        assert len(path_item.parameters) == 1
+        assert isinstance(path_item.parameters[0], cicerone_spec.Parameter)
+        assert path_item.parameters[0].name == "id"
+
+    def test_path_level_ref(self):
+        path_item = cicerone_spec.PathItem.from_dict("/users", {"$ref": "#/components/pathItems/Users"})
+        assert path_item.ref == "#/components/pathItems/Users"
+
+
+class TestResolverWithTypedRefs:
+    """The reference resolver uses the typed ref field."""
+
+    def test_nested_typed_refs_resolved(self):
+        spec = parse_spec_from_dict(
+            {
+                "openapi": "3.0.0",
+                "info": {"title": "Test", "version": "1.0.0"},
+                "paths": {},
+                "components": {
+                    "schemas": {
+                        "User": {
+                            "type": "object",
+                            "properties": {"address": {"$ref": "#/components/schemas/Address"}},
+                        },
+                        "Address": {"type": "object", "properties": {"city": {"type": "string"}}},
+                    }
+                },
+            }
+        )
+        user = spec.resolve_reference("#/components/schemas/User")
+        assert isinstance(user, cicerone_spec.Schema)
+        address = user.properties["address"]
+        assert isinstance(address, cicerone_spec.Schema)
+        assert address.properties["city"].type == "string"
+
+    def test_components_schema_has_typed_ref_property(self):
+        spec = parse_spec_from_dict(
+            {
+                "openapi": "3.0.0",
+                "info": {"title": "Test", "version": "1.0.0"},
+                "paths": {},
+                "components": {
+                    "schemas": {
+                        "Pet": {"type": "object", "properties": {"owner": {"$ref": "#/components/schemas/Owner"}}},
+                        "Owner": {"type": "object"},
+                    }
+                },
+            }
+        )
+        pet = spec.components.schemas["Pet"]
+        assert pet.properties["owner"].ref == "#/components/schemas/Owner"
+
+
+class TestEndToEndTypedParsing:
+    """Full spec parse produces a fully typed tree."""
+
+    def test_full_operation_tree_is_typed(self):
+        spec = parse_spec_from_dict(
+            {
+                "openapi": "3.1.0",
+                "info": {"title": "Test", "version": "1.0.0"},
+                "paths": {
+                    "/users": {
+                        "post": {
+                            "operationId": "createUser",
+                            "deprecated": True,
+                            "requestBody": {
+                                "content": {"application/json": {"schema": {"$ref": "#/components/schemas/User"}}}
+                            },
+                            "responses": {"201": {"description": "Created"}},
+                        }
+                    }
+                },
+                "components": {"schemas": {"User": {"type": "object"}}},
+            }
+        )
+        operation = spec.operation_by_operation_id("createUser")
+        assert operation is not None
+        assert operation.deprecated is True
+        assert operation.request_body.content["application/json"].schema_.ref == "#/components/schemas/User"
+        assert operation.responses["201"].description == "Created"

--- a/tests/spec/test_typed_fields.py
+++ b/tests/spec/test_typed_fields.py
@@ -138,7 +138,7 @@ class TestSchemaTypedFields:
 
     def test_construction_by_field_name(self):
         # populate_by_name allows programmatic construction with snake_case names
-        schema = cicerone_spec.Schema(ref="#/components/schemas/User", min_length=3)
+        schema = cicerone_spec.Schema(ref="#/components/schemas/User", min_length=3)  # ty: ignore[unknown-argument]
         assert schema.ref == "#/components/schemas/User"
         assert schema.min_length == 3
 
@@ -157,6 +157,7 @@ class TestSchemaExtrasMirroring:
         }
         schema = cicerone_spec.Schema.from_dict(data)
         extra = schema.model_extra
+        assert extra is not None
         assert extra["$ref"] == "#/components/schemas/User"
         assert extra["enum"] == ["a", "b"]
         assert extra["default"] == "a"
@@ -167,17 +168,23 @@ class TestSchemaExtrasMirroring:
     def test_mirrored_values_are_raw_not_models(self):
         data = {"discriminator": {"propertyName": "petType"}, "additionalProperties": {"type": "string"}}
         schema = cicerone_spec.Schema.from_dict(data)
-        assert schema.model_extra["discriminator"] == {"propertyName": "petType"}
-        assert schema.model_extra["additionalProperties"] == {"type": "string"}
+        extra = schema.model_extra
+        assert extra is not None
+        assert extra["discriminator"] == {"propertyName": "petType"}
+        assert extra["additionalProperties"] == {"type": "string"}
 
     def test_absent_keys_not_mirrored(self):
         schema = cicerone_spec.Schema.from_dict({"type": "string"})
-        assert "enum" not in schema.model_extra
-        assert "$ref" not in schema.model_extra
+        extra = schema.model_extra
+        assert extra is not None
+        assert "enum" not in extra
+        assert "$ref" not in extra
 
     def test_vendor_extensions_still_in_extras(self):
         schema = cicerone_spec.Schema.from_dict({"type": "string", "x-internal": True})
-        assert schema.model_extra["x-internal"] is True
+        extra = schema.model_extra
+        assert extra is not None
+        assert extra["x-internal"] is True
 
 
 class TestOperationTypedFields:
@@ -291,9 +298,11 @@ class TestOperationTypedFields:
         }
         operation = cicerone_spec.Operation.from_dict("POST", "/users", data)
         # Raw values mirrored for pre-0.4.0 consumers (removed in 0.5.0)
-        assert operation.model_extra["requestBody"] == data["requestBody"]
-        assert operation.model_extra["security"] == [{"apiKey": []}]
-        assert operation.model_extra["deprecated"] is True
+        extra = operation.model_extra
+        assert extra is not None
+        assert extra["requestBody"] == data["requestBody"]
+        assert extra["security"] == [{"apiKey": []}]
+        assert extra["deprecated"] is True
 
 
 class TestMediaTypeTypedSchema:
@@ -319,7 +328,9 @@ class TestParameterTypedFields:
     def test_ref_field(self):
         parameter = cicerone_spec.Parameter.from_dict({"$ref": "#/components/parameters/PageSize"})
         assert parameter.ref == "#/components/parameters/PageSize"
-        assert parameter.model_extra["$ref"] == "#/components/parameters/PageSize"
+        extra = parameter.model_extra
+        assert extra is not None
+        assert extra["$ref"] == "#/components/parameters/PageSize"
 
     def test_deprecated_and_allow_empty_value(self):
         parameter = cicerone_spec.Parameter.from_dict(
@@ -379,7 +390,7 @@ class TestLinkTypedFields:
     def test_old_camel_case_access_still_works_via_extras(self):
         link = cicerone_spec.Link.from_dict({"operationId": "getUser"})
         # Deprecated compat: pre-0.4.0 attribute access (removed in 0.5.0)
-        assert link.operationId == "getUser"
+        assert link.operationId == "getUser"  # ty: ignore[unresolved-attribute]
 
 
 class TestPathItemTypedFields:

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -147,7 +147,7 @@ wheels = [
 
 [[package]]
 name = "cicerone"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

This release promotes spec-defined fields that previously only appeared in `model_extra` to proper typed model fields across the OpenAPI spec models. Raw values are mirrored in `model_extra` for backwards compatibility (deprecated, to be removed in 0.5.0).

## Key Changes

### Schema Model
- Added typed fields for JSON Schema / OpenAPI keywords: `ref` (`$ref`), `format`, `enum`, `default`, `const`, `deprecated`, `nullable`, `read_only`, `write_only`, `example`, `examples`, `discriminator`, `additional_properties`, and numeric/string/array/object constraint fields
- Added `has_default` and `has_const` properties to distinguish explicit `null` values from absent fields
- Added `types` property (always-a-list view of `type` keyword for OpenAPI 3.1 compatibility)
- Added `primary_type` and `is_nullable` properties for unified 3.0/3.1 type handling
- Implemented `SpecModel` base class with declarative `from_dict()` for nested field parsing

### Operation Model
- Promoted `parameters` to `list[Parameter]` (typed), `responses` to `dict[str, Response]` (typed)
- Added typed fields: `request_body`, `security`, `callbacks`, `deprecated`, `servers`, `external_docs`
- Implemented proper nested parsing for complex objects

### Other Models
- **Parameter**: Added `ref`, `deprecated`, `allow_empty_value` typed fields
- **Header**: Added `ref`, `deprecated` typed fields
- **RequestBody/Response**: Added `ref` typed field
- **MediaType**: `schema_` is now typed `Schema` instead of raw dict
- **Encoding**: `headers` is now `dict[str, Header]` instead of raw dict
- **Link**: Converted to snake_case fields (`operation_ref`, `operation_id`, `request_body`) with camelCase aliases; added typed `server`
- **PathItem**: Added `ref`, `summary`, `description` typed fields; path-level `parameters` now typed
- **New Discriminator model**: Represents OpenAPI discriminator objects with `property_name` and `mapping`

### Query API Improvements
- Added `operations_by_tag(tag)` to filter operations by tag
- Added `tags_to_operations()` to group all operations by tag
- Added `__iter__()` to `Paths` for direct iteration over (path, PathItem) pairs
- Implemented reference caching in `ReferenceResolver` for performance

### Backwards Compatibility
- Raw values from promoted fields are mirrored into `model_extra` via new `mirror_extras()` helper
- All models support `populate_by_name=True` for programmatic construction with snake_case names
- Pre-0.4.0 access patterns like `schema.model_extra.get("enum")` continue to work (deprecated)

### Infrastructure
- Created `SpecModel` base class with declarative nested field parsing via `NESTED_FIELDS` and `MIRRORED_EXTRA_KEYS` class variables
- Updated version to 0.4.0 in pyproject.toml
- Comprehensive test coverage for all new typed fields and backwards compatibility

## Notable Implementation Details

- The `from_dict()` pattern in `SpecModel` separates nested field parsing (handled declaratively) from Pydantic validation, enabling proper type conversion while preserving raw values for mirroring
- OpenAPI 3.1 type arrays are supported natively via `type: str | list[str]` with helper properties for unified access
- Reference resolution is now cached per spec instance to improve performance on repeated lookups
- Circular reference detection is preserved in the resolver

https://claude.ai/code/session_012uMV8n26pbFxhKLu83rTjE